### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
-All software in this package is part of FIS GT.M (http://fis-gtm.com) which is Copyright 2017 Fidelity Information
-Services, Inc., and provided to you under the terms of a license. If there is a COPYING file included in this package,
-it contains the terms of the license under which the package is provided to you. If there is not a COPYING file in the
-package, you must ensure that your use of FIS GT.M complies with the license under which it is provided. If you are
-unsure as to the terms of your license, please consult with the entity that provided you with the package.
+All software in this package is part of YottaDB (http://yottadb.com) each file of which contains notices from its copyright holders. YottaDB is provided to you under the terms of a license that you must comply with. If there is a COPYING file included in this package, it contains the terms of the license under which the package is provided to you.
+
+If there is not a COPYING file in the package, you must do one of the following:
+ (a) Ensure that there is a signed license under which the software is made available to you.
+ (b) Create a COPYING file by copying the contents of https://www.gnu.org/licenses/agpl.txt and use it as the license.


### PR DESCRIPTION
Replace FIS and Fidelity Information Services with YottaDB and YottaDB respectively, reword for clarity, provide an option to use the GNU Affero General Public License if the license is not clear.