### PR TITLE
Fix copyright.txt to have 2017 as the only year (first year of YottaD…

### DIFF
--- a/sr_port/copyright.txt
+++ b/sr_port/copyright.txt
@@ -2,7 +2,7 @@
  Copyright (c) XXXX-YYYY Fidelity National Information		
  Services, Inc. and/or its subsidiaries. All rights reserved.	
 								
- Copyright (c) YYYY YottaDB LLC. and/or its subsidiaries.	
+ Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	
  All rights reserved.						
 								
 	This source code contains the intellectual property	


### PR DESCRIPTION
…B) for now and use XXXX/YYYY format from 2018 onwards