### PR TITLE
[YDB#12] [NARS] [estess] Maintain clue (to speed up future database a…

### DIFF
--- a/sr_port/gdsfhead.h
+++ b/sr_port/gdsfhead.h
@@ -3482,8 +3482,19 @@ MBSTART {															\
  */
 #define	GVT_CLUE_INVALIDATE_FIRST_REC(GVT)						\
 MBSTART {										\
+	gv_key *firstRec;								\
+											\
 	assert(GVT->clue.end);								\
-	*((short *)GVT->first_rec->base) = GVT_CLUE_FIRST_REC_UNRELIABLE;		\
+	firstRec = GVT->first_rec;							\
+	*((short *)firstRec->base) = GVT_CLUE_FIRST_REC_UNRELIABLE;			\
+	/* The below lines are needed by an assert in DEBUG_GVT_CLUE_VALIDATE macro	\
+	 * In pro, we only use first_rec->base and don't use first_rec->end and since	\
+	 * the first byte is 0xff (greater than first valid mname which is an alphabet)	\
+	 * we are guaranteed the memcmp will stop right after the first byte.		\
+	 */										\
+	DEBUG_ONLY(firstRec->base[2] = KEY_DELIMITER);					\
+	DEBUG_ONLY(firstRec->base[3] = KEY_DELIMITER);					\
+	DEBUG_ONLY(firstRec->end = 3);							\
 } MBEND
 
 #ifdef DEBUG

--- a/sr_port/gvcst_blk_search.c
+++ b/sr_port/gvcst_blk_search.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2015 Fidelity National Information 	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -71,8 +74,8 @@
  *				PREVIOUS REC	CURRENT REC
  * CONDITION			MATCH	OFFSET	MATCH	OFFSET
  * ---------			----	------	-----	------
- * Buffer empty			0	0	0	7
- * Hit first key in block	0	0	a	7
+ * Buffer empty			0	0	0	f
+ * Hit first key in block	0	0	a	f
  * Hit star key			b	c	0	x
  * Hit last key (leaf)		b	c	a	x
  * Went past last key (leaf)	b	x	0	y
@@ -82,6 +85,7 @@
  *	b = number of characters which match on the previous
  *	    key (including those which have been compressed away)
  *	c = offset of previous record
+ *	f = offset of first record in the block (i.e. SIZEOF(blk_hdr))
  *	x = offset for last record in the block
  *	y = top of buffer (same as block bsize)
  *

--- a/sr_port/gvcst_blk_search.h
+++ b/sr_port/gvcst_blk_search.h
@@ -346,6 +346,7 @@ GBLREF	uint4			dollar_tlevel;
 	assert(PREV_REC_UNINITIALIZED != pStat->prev_rec.match);
 	assert(PREV_REC_UNINITIALIZED != pStat->prev_rec.offset);
 	pStat->curr_rec.offset = (unsigned short)(pRecBase - pBlkBase);
+	assert(pStat->curr_rec.offset >= SIZEOF(blk_hdr));
 	pStat->curr_rec.match = (unsigned short)nTargLen;
 #	ifdef GVCST_SEARCH_EXPAND_PREVKEY
 	if (NULL != (tmpPtr = prevKeyUnCmp))	/* Note: Assignment */

--- a/sr_port/gvcst_kill.c
+++ b/sr_port/gvcst_kill.c
@@ -814,8 +814,14 @@ research:
 		if (!killing_chunks)
 			INCR_GVSTATS_COUNTER(csa, cnl, n_kill, 1);
 		if (gvt_root && (0 != gv_target->clue.end))
-		{	/* If clue is still valid, then the deletion was confined to a single block */
-			assert(gvt_hist->h[0].blk_num == alt_hist->h[0].blk_num);
+		{	/* If clue is still valid, then the deletion was confined to a single block. Assert that the block
+			 * numbers are identical. The only exception is if a GVTR_OP_TCOMMIT happened above causing
+			 * the blk_num in gvt_hist->h[0] to be assigned a valid block while alt_hist->h[0].blk_num stayed
+			 * an invalid block (the # that gets assigned to to-be-created block numbers while inside a TP fence).
+			 */
+			assert((gvt_hist->h[0].blk_num == alt_hist->h[0].blk_num)
+				|| (lcl_implicit_tstart && ((off_chain *)&alt_hist->h[0].blk_num)->flag
+					&& !((off_chain *)&gvt_hist->h[0].blk_num)->flag));
 			/* In this case, the "right hand" key (which was searched via gv_altkey) was the last search
 			 * and should become the clue.  Furthermore, the curr.match from this last search should be
 			 * the history's curr.match.  However, this record will have been shuffled to the position of


### PR DESCRIPTION
…ccesses) for $order(^x("")) case and few other similar cases

Release Note
-------------
Repeated calls to $order(^xxx("")) where xxx is a global name run faster. (YDB#12)

Test
-----
* E_ALL run many times to ensure no regressions.

README
-------
The main change was to gvcst_search.c. If the search key lands before the first key in the block (a special case),
the clue was previously not being maintained. This meant future search of the same key would redo the entire
traversal of the Global Variable Tree. $order(^x("")) is an example of this kind of search where the $order function
constructs a non-existent search key that is guaranteed to be before the first key in any leaf block. Turns out all
that is needed is to invalidate the first_rec part of the clue. This way searches of keys >= clue and <= last_rec can
still be satisfied using the clue even though the first_rec is unusable. Since there was already a scheme to
invalidate the first_rec part of the clue, all that was needed was to enhance the clue maintenance to do something
similar in this special case.

In addition, there were some miscellaneous changes.

* Dbg-only changes needed to GVT_CLUE_INVALIDATE_FIRST_REC macro to take care of a few asserts
* Fixing some comments in gvcst_blk_search.c
* Add an assert in gvcst_blk_search.h
* Adjust an assert in gvcst_kill.c since the clue is now non-zero in more situations than before (triggers/testxecute
	subtest failed this assert).