### PR TITLE
Expose needed symbols in cmake build to get ^%YGBLSTAT working (for e…

### DIFF
--- a/sr_linux/platform.cmake
+++ b/sr_linux/platform.cmake
@@ -3,6 +3,9 @@
 # Copyright (c) 2013-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.                                          #
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -69,6 +72,7 @@ set(gtm_link  "-Wl,-u,gtm_filename_to_id -Wl,-u,gtm_zstatus -Wl,--version-script
 set(gtm_dep   "${GTM_BINARY_DIR}/gtmexe_symbols.export")
 
 set(libgtmshr_link "-Wl,-u,gtm_ci -Wl,-u,gtm_filename_to_id -Wl,-u,gtm_is_main_thread")
+set(libgtmshr_link "${libgtmshr_link} -Wl,-u,accumulate -Wl,-u,is_big_endian -Wl,-u,to_ulong")
 set(libgtmshr_link "${libgtmshr_link} -Wl,--version-script,\"${GTM_BINARY_DIR}/gtmshr_symbols.export\"")
 set(libgtmshr_dep  "${GTM_BINARY_DIR}/gtmexe_symbols.export")
 


### PR DESCRIPTION
…xample statsdb/ygblstat subtest fails due to this issue)