### PR TITLE
[NARS1] [estess] OFRZAUTOREL message should indicate database file full path instead of ambiguous region name #47

### DIFF
--- a/sr_port/gdsfhead.h
+++ b/sr_port/gdsfhead.h
@@ -1812,7 +1812,7 @@ MBSTART {														\
 			(CSD)->freeze = FALSE;										\
 			(CSD)->image_count = 0;										\
 			(CSD)->freeze_online = CHILLED_AUTORELEASE_MASK | CHILLED_AUTORELEASE_REPORT_MASK;		\
-			send_msg_csa(CSA_ARG(CSA) VARLSTCNT(9) ERR_OFRZAUTOREL, 2, REG_LEN_STR((CSA)->region),		\
+			send_msg_csa(CSA_ARG(CSA) VARLSTCNT(9) ERR_OFRZAUTOREL, 2, DB_LEN_STR((CSA)->region),		\
 					ERR_ERRCALL, 3, CALLFROM);							\
 		}													\
 		if (!was_latch)												\

--- a/sr_port/merrors.msg
+++ b/sr_port/merrors.msg
@@ -1635,7 +1635,7 @@ RESYNCSEQLOW	<MUPIP JOURNAL -ROLLBACK -FORWARD -RESYNC=!@ZQ [0x!16@XQ] requested
 DBNULCOL	<NULL collation representation for record !UL in block !UL is !AD which differs from the database file header settings of !AD>/error/fao=6!/ansi=0
 UTF16ENDIAN	<The device previously set UTF-16 endianness to !AD and cannot change to !AD>/error/fao=4!/ansi=0
 OFRZACTIVE	<Region !AD has an Online Freeze>/warning/fao=2!/ansi=0
-OFRZAUTOREL	<Online Freeze automatically released for region !AD>/warning/fao=2!/ansi=0
+OFRZAUTOREL	<Online Freeze automatically released for database file !AD>/warning/fao=2!/ansi=0
 OFRZCRITREL	<Proceeding with a write to region !AD after Online Freeze while holding crit>/warning/fao=2!/ansi=0
 OFRZCRITSTUCK	<Unable to proceed with a write to region !AD with Online Freeze while holding crit. Region stuck until freeze is removed.>/warning/fao=2!/ansi=0
 OFRZNOTHELD	<Online Freeze had been automatically released for at least one region>/warning/fao=0!/ansi=0

--- a/sr_x86_64/merrors_ctl.c
+++ b/sr_x86_64/merrors_ctl.c
@@ -1467,7 +1467,7 @@ LITDEF	err_msg merrors[] = {
 	{ "DBNULCOL", "NULL collation representation for record !UL in block !UL is !AD which differs from the database file header settings of !AD", 6 },
 	{ "UTF16ENDIAN", "The device previously set UTF-16 endianness to !AD and cannot change to !AD", 4 },
 	{ "OFRZACTIVE", "Region !AD has an Online Freeze", 2 },
-	{ "OFRZAUTOREL", "Online Freeze automatically released for region !AD", 2 },
+	{ "OFRZAUTOREL", "Online Freeze automatically released for database file !AD", 2 },
 	{ "OFRZCRITREL", "Proceeding with a write to region !AD after Online Freeze while holding crit", 2 },
 	{ "OFRZCRITSTUCK", "Unable to proceed with a write to region !AD with Online Freeze while holding crit. Region stuck until freeze is removed.", 2 },
 	{ "OFRZNOTHELD", "Online Freeze had been automatically released for at least one region", 0 },


### PR DESCRIPTION

Release Note
-------------
The OFRZAUTOREL message displays the full path of the database file name instead of a potentially-ambiguous region name.

Test
----
* E_ALL run to ensure no regressions.
* v63001/gtm8362 subtest enhanced to search for OFRZAUTOREL message coming only from the test output directory
	of interest. Previously, if two concurrent gtm8362 tests were running, it was possible for one test
	to be confused by the OFRZAUTOREL message of another test (since the message only indicated the region
	name). Now the OFRZAUTOREL message contains the test output directory path so it can clearly identify
	messages that correspond to its database file of interest.