### PR TITLE
[YDB#50] [NARS1] [estess] Change all GT.M release name usages (e.g. now_running field in db shared memory) to YottaDB release names

### DIFF
--- a/sr_i386/incr_link.c
+++ b/sr_i386/incr_link.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2015 Fidelity National Information 	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -29,9 +32,6 @@
 #include "gtm_text_alloc.h"
 
 /* INCR_LINK - read and process a mumps object module. Link said module to currently executing image */
-
-LITREF char gtm_release_name[];
-LITREF int4 gtm_release_name_len;
 
 static char 		*code;
 GBLREF mident_fixed 	zlink_mname;

--- a/sr_i386/obj_file.c
+++ b/sr_i386/obj_file.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2014 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2014 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -30,9 +33,6 @@
 #include "gtmio.h"
 #include "mmemory.h"
 #include "obj_file.h"
-
-LITREF char gtm_release_name[];
-LITREF int4 gtm_release_name_len;
 
 GBLREF mliteral 	literal_chain;
 GBLREF char 		source_file_name[];

--- a/sr_linux/release_name.h
+++ b/sr_linux/release_name.h
@@ -14,23 +14,21 @@
  ****************************************************************/
 
 #ifndef GTM_RELEASE_NAME
-#ifdef __CYGWIN__
-#define GTM_RELEASE_NAME 	"GT.M V6.3-002 CYGWIN x86"
-#define YDB_RELEASE_NAME 	"YottaDB r1.00 CYGWIN x86"
-#elif defined(__ia64)
-#define GTM_RELEASE_NAME 	"GT.M V6.3-002 Linux IA64"
-#define YDB_RELEASE_NAME 	"YottaDB r1.00 Linux IA64"
-#elif defined(__x86_64__)
-#define GTM_RELEASE_NAME 	"GT.M V6.3-002 Linux x86_64"
-#define YDB_RELEASE_NAME 	"YottaDB r1.00 Linux x86_64"
-#elif defined(__s390__)
-#define GTM_RELEASE_NAME 	"GT.M V6.3-002 Linux S390X"
-#define YDB_RELEASE_NAME 	"YottaDB r1.00 Linux S390X"
+
+#define GTM_VERSION	"V6.3"
+#define	GTM_ZVERSION	"V6.3-002"
+#define	YDB_ZYRELEASE	"r1.10"
+
+#if defined(__x86_64__)
+# define YDB_PLATFORM		"Linux x86_64"
 #else
-#define GTM_RELEASE_NAME 	"GT.M V6.3-002 Linux x86"
-#define YDB_RELEASE_NAME 	"YottaDB r1.00 Linux x86"
+# define YDB_PLATFORM		"Linux x86"
 #endif
-#endif
+
+#define GTM_RELEASE_NAME 	"GT.M" " " GTM_ZVERSION " " YDB_PLATFORM
+#define YDB_RELEASE_NAME 	"YottaDB" " " YDB_ZYRELEASE " " YDB_PLATFORM
+#define	YDB_AND_GTM_RELEASE_NAME	GTM_RELEASE_NAME " " "YottaDB" " " YDB_ZYRELEASE
 #define GTM_PRODUCT 		"GT.M"
 #define YDB_PRODUCT		"YottaDB"
-#define GTM_VERSION		"V6.3"
+
+#endif

--- a/sr_port/gdsbt.h
+++ b/sr_port/gdsbt.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -527,7 +530,7 @@ typedef struct node_local_struct
 {
 	unsigned char   label[GDS_LABEL_SZ];			/* 12	signature for GDS shared memory */
 	unsigned char	fname[MAX_FN_LEN + 1];			/* 256	filename of corresponding database */
-	char		now_running[MAX_REL_NAME];		/* 36	current active GT.M version stamp */
+	char		now_running[MAX_REL_NAME];		/* 36	current active YottaDB version stamp */
 	char		machine_name[MAX_MCNAMELEN];		/* 256	machine name for clustering */
 	sm_off_t	bt_header_off;				/* (QW alignment) offset to hash table */
 	sm_off_t	bt_base_off;				/* bt first entry */

--- a/sr_port/gtm_assert.c
+++ b/sr_port/gtm_assert.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2011 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2011 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -29,13 +32,13 @@
 #include "mdef.h"
 #include "send_msg.h"
 
-LITREF char	gtm_release_name[];
-LITREF int4	gtm_release_name_len;
+LITREF char	ydb_release_name[];
+LITREF int4	ydb_release_name_len;
 
 error_def(ERR_GTMASSERT);
 
 void	gtm_assert(int file_name_len, char file_name[], int line_no)
 {
-	send_msg (VARLSTCNT(7) ERR_GTMASSERT, 5, gtm_release_name_len, gtm_release_name, file_name_len, file_name, line_no);
-	rts_error (VARLSTCNT(7) ERR_GTMASSERT, 5, gtm_release_name_len, gtm_release_name, file_name_len, file_name, line_no);
+	send_msg (VARLSTCNT(7) ERR_GTMASSERT, 5, ydb_release_name_len, ydb_release_name, file_name_len, file_name, line_no);
+	rts_error (VARLSTCNT(7) ERR_GTMASSERT, 5, ydb_release_name_len, ydb_release_name, file_name_len, file_name, line_no);
 }

--- a/sr_port/gtm_assert2.c
+++ b/sr_port/gtm_assert2.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2011 Fidelity Information Services, Inc	*
+ * Copyright 2011 Fidelity Information Services, Inc		*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -20,16 +23,16 @@
 #include "mdef.h"
 #include "send_msg.h"
 
-LITREF char	gtm_release_name[];
-LITREF int4	gtm_release_name_len;
+LITREF char	ydb_release_name[];
+LITREF int4	ydb_release_name_len;
 
 error_def(ERR_GTMASSERT2);
 
 int gtm_assert2(int condlen, char *condtext, int file_name_len, char file_name[], int line_no)
 {
-	send_msg(VARLSTCNT(9) ERR_GTMASSERT2, 7, gtm_release_name_len, gtm_release_name, file_name_len, file_name, line_no,
-		 condlen, condtext);
-	rts_error(VARLSTCNT(9) ERR_GTMASSERT2, 7, gtm_release_name_len, gtm_release_name, file_name_len, file_name, line_no,
-		  condlen, condtext);
+	send_msg(VARLSTCNT(9) ERR_GTMASSERT2, 7, ydb_release_name_len, ydb_release_name,
+					file_name_len, file_name, line_no, condlen, condtext);
+	rts_error(VARLSTCNT(9) ERR_GTMASSERT2, 7, ydb_release_name_len, ydb_release_name,
+					file_name_len, file_name, line_no, condlen, condtext);
 	return 0;	/* Required for assertpro() macro which assumes (syntactically) this rtn returns a result */
 }

--- a/sr_port/gvcst_init.c
+++ b/sr_port/gvcst_init.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -143,8 +146,6 @@ GBLREF	boolean_t		pool_init;
 GBLREF	boolean_t		jnlpool_init_needed;
 GBLREF	jnlpool_addrs		jnlpool;
 GBLREF	uint4			process_id;
-LITREF char			gtm_release_name[];
-LITREF int4			gtm_release_name_len;
 LITREF mval			literal_statsDB_gblname;
 
 #define MAX_DBINIT_RETRY	3

--- a/sr_port/mu_dwngrd_header.c
+++ b/sr_port/mu_dwngrd_header.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2005, 2011 Fidelity Information Services, Inc	*
+ * Copyright 2005, 2011 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -35,8 +38,8 @@
 #include "mu_upgrd_dngrd_hdr.h"
 #include "gtmmsg.h"
 
-LITREF  char	gtm_release_name[];
-LITREF  int4	gtm_release_name_len;
+LITREF  char	ydb_release_name[];
+LITREF  int4	ydb_release_name_len;
 
 error_def(ERR_MUINFOUINT8);
 
@@ -78,7 +81,7 @@ void mu_dwngrd_header(sgmnt_data *csd, v15_sgmnt_data *v15_csd)
 	v15_csd->last_com_backup = (v15_trans_num)csd->last_com_backup;
 	v15_csd->last_rec_backup = (v15_trans_num)csd->last_rec_backup;
 	v15_csd->reorg_restart_block = csd->reorg_restart_block;
-	memcpy(v15_csd->now_running, gtm_release_name, gtm_release_name_len + 1);	/* GT.M release name */
+	memcpy(v15_csd->now_running, ydb_release_name, ydb_release_name_len + 1);	/* YottaDB release name */
 	VMS_ONLY(v15_csd->owner_node = csd->owner_node;)
 	v15_csd->image_count = csd->image_count;
 	v15_csd->kill_in_prog = (csd->kill_in_prog + csd->abandoned_kills);

--- a/sr_port/mu_upgrd_header.c
+++ b/sr_port/mu_upgrd_header.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2012 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2012 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -37,8 +40,8 @@
 #include "lockconst.h"
 #include "wcs_phase2_commit_wait.h"
 
-LITREF  char                    gtm_release_name[];
-LITREF  int4                    gtm_release_name_len;
+LITREF  char                    ydb_release_name[];
+LITREF  int4                    ydb_release_name_len;
 
 error_def(ERR_MUINFOUINT8);
 
@@ -84,7 +87,7 @@ void mu_upgrd_header(v15_sgmnt_data *v15_csd, sgmnt_data *csd)
 	csd->last_com_backup = v15_csd->last_com_backup;
 	csd->last_rec_backup = v15_csd->last_rec_backup;
 	csd->reorg_restart_block = v15_csd->reorg_restart_block;		/* New from V4.2 */
-	memcpy(csd->now_running, gtm_release_name, gtm_release_name_len + 1);	/* GT.M release name */
+	memcpy(csd->now_running, ydb_release_name, ydb_release_name_len + 1);	/* YottaDB release name */
 	VMS_ONLY(csd->owner_node = v15_csd->owner_node;)
 	csd->image_count = v15_csd->image_count;
 	csd->kill_in_prog = 0;

--- a/sr_port/mupip_backup.c
+++ b/sr_port/mupip_backup.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -129,9 +132,6 @@ GBLREF	jnlpool_ctl_ptr_t	jnlpool_ctl;
 GBLREF	uint4			mutex_per_process_init_pid;
 GBLREF	boolean_t		holds_sem[NUM_SEM_SETS][NUM_SRC_SEMS];
 GBLREF	boolean_t		pool_init;
-
-LITREF char             gtm_release_name[];
-LITREF int4             gtm_release_name_len;
 
 error_def(ERR_BACKUPCTRL);
 error_def(ERR_BACKUPKILLIP);

--- a/sr_port/mupip_downgrade.c
+++ b/sr_port/mupip_downgrade.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2005-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -52,9 +55,6 @@
 
 #define	GTM_VER_LIT		"GT.M "
 #define	MAX_VERSION_LEN		16	/* 16 bytes enough to hold V63000A, longest -VERSION= value possible */
-
-LITREF  char     	 	gtm_release_name[];
-LITREF  int4            	gtm_release_name_len;
 
 static sem_info	*sem_inf;
 

--- a/sr_port/mupip_upgrade.c
+++ b/sr_port/mupip_upgrade.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2005-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -56,8 +59,8 @@
 #include "mu_all_version_standalone.h"
 #include "db_write_eof_block.h"
 
-LITREF  char            	gtm_release_name[];
-LITREF  int4           		gtm_release_name_len;
+LITREF  char            	ydb_release_name[];
+LITREF  int4           		ydb_release_name_len;
 
 UNIX_ONLY(static sem_info	*sem_inf;)
 
@@ -213,7 +216,7 @@ void mupip_upgrade(void)
 			gtm_putmsg_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TEXT, 2,
 					LEN_AND_LIT("Maximum master map size is now increased from 32K to 56K"));
 			gtm_putmsg_csa(CSA_ARG(NULL) VARLSTCNT(8) ERR_MUPGRDSUCC, 6, db_fn_len, db_fn,
-					RTS_ERROR_LITERAL("upgraded"), gtm_release_name_len, gtm_release_name);
+					RTS_ERROR_LITERAL("upgraded"), ydb_release_name_len, ydb_release_name);
 			mupip_exit(SS_NORMAL);
 		}
 		F_CLOSE(channel, rc);	/* resets "channel" to FD_INVALID */
@@ -268,7 +271,7 @@ void mupip_upgrade(void)
 	{
 		F_CLOSE(channel, rc);	/* resets "channel" to FD_INVALID */
 		gtm_putmsg_csa(CSA_ARG(NULL) VARLSTCNT(6) ERR_MUUPGRDNRDY, 4, db_fn_len, db_fn,
-								gtm_release_name_len, gtm_release_name);
+								ydb_release_name_len, ydb_release_name);
 		mupip_exit(ERR_MUNOUPGRD);
 	}
 	max_max_rec_size = v15_csd.blk_size - SIZEOF(blk_hdr);
@@ -321,7 +324,7 @@ void mupip_upgrade(void)
 	F_CLOSE(channel, rc);	/* resets "channel" to FD_INVALID */
 	mu_all_version_release_standalone(sem_inf);
 	gtm_putmsg_csa(CSA_ARG(NULL) VARLSTCNT(8) ERR_MUPGRDSUCC, 6, db_fn_len, db_fn, RTS_ERROR_LITERAL("upgraded"),
-		   								gtm_release_name_len, gtm_release_name);
+		   							ydb_release_name_len, ydb_release_name);
 	mupip_exit(SS_NORMAL);
 }
 

--- a/sr_port_cm/gtcm_protocol.c
+++ b/sr_port_cm/gtcm_protocol.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2010 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2010 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -46,8 +49,7 @@ LITDEF	gtcm_proto_os_info_t	gtcm_proto_os_info[] =
 	{LIT_AND_LEN(GTCM_PROTO_BAD_OS),	GTCM_PROTO_BAD_OS}
 };
 
-LITREF	char		gtm_release_name[];
-LITREF	int4		gtm_release_name_len;
+LITREF	char		ydb_release_name[];
 LITREF	char		gtm_version[];
 LITREF	char 		cm_ver_name[];
 LITREF	int4		cm_ver_len;
@@ -107,7 +109,7 @@ static char *encode_cpu()
 	int		count, cpuidx;
 
 	count = 0;
-	p = (unsigned char *)gtm_release_name;
+	p = (unsigned char *)ydb_release_name;
 	/* fourth arg in release name string */
 	while (*p && count < 3)
 	{
@@ -134,7 +136,7 @@ static char *encode_os()
 	int		count, osidx;
 
 	count = 0;
-	p = (unsigned char *)gtm_release_name;
+	p = (unsigned char *)ydb_release_name;
 	/* third arg in release name string */
 	while (*p && count < 2)
 	{

--- a/sr_unix/dse_help.c
+++ b/sr_unix/dse_help.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2013 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2013 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -10,6 +13,7 @@
  ****************************************************************/
 
 #include "mdef.h"
+
 #include "gdsroot.h"
 #include "gtm_facility.h"
 #include "fileinfo.h"
@@ -19,6 +23,9 @@
 #include "util.h"
 #include "dse.h"
 
+LITREF char	ydb_release_name[];
+LITREF int4	ydb_release_name_len;
+
 void dse_help(void)
 {
 	/* This function is a STUB to avoid editting sr_port/dse.h */
@@ -26,23 +33,6 @@ void dse_help(void)
 
 void dse_version(void)
 {
-	/*
-	 * The following assumptions have been made in this function
-	 * 1. GTM_RELEASE_NAME is of the form "GTM_PRODUCT VERSION THEREST"
-	 *    (Refer file release_name.h)
-	 * 2. A single blank separates GTM_PRODUCT and VERSION
-	 * 3. If THEREST exists, it is separated from VERSION by atleast
-	 *    one blank
-	 */
-	char gtm_rel_name[] = GTM_RELEASE_NAME;
-	char dse_rel_name[SIZEOF(GTM_RELEASE_NAME) - SIZEOF(GTM_PRODUCT)];
-	int  dse_rel_name_len;
-	char *cptr;
-
-	for (cptr = gtm_rel_name + SIZEOF(GTM_PRODUCT), dse_rel_name_len = 0;
-	     *cptr != ' ' && *cptr != '\0';
-	     dse_rel_name[dse_rel_name_len++] = *cptr++);
-	dse_rel_name[dse_rel_name_len] = '\0';
-	util_out_print("!AD", TRUE, dse_rel_name_len, dse_rel_name);
+	util_out_print("!AD", TRUE, ydb_release_name_len, ydb_release_name);
 	return;
 }

--- a/sr_unix/gds_rundown.c
+++ b/sr_unix/gds_rundown.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -102,8 +105,8 @@ GBLREF	int			process_exiting;
 GBLREF	boolean_t		ok_to_UNWIND_in_exit_handling;
 GBLREF	gv_namehead		*gv_target_list;
 
-LITREF  char                    gtm_release_name[];
-LITREF  int4                    gtm_release_name_len;
+LITREF  char                    ydb_release_name[];
+LITREF  int4                    ydb_release_name_len;
 LITREF gtmImageName		gtmImageNames[];
 
 error_def(ERR_AIOCANCELTIMEOUT);
@@ -412,7 +415,7 @@ int4 gds_rundown(boolean_t cleanup_udi)
 	 * both callers. Therefore use interlocked INCR_CNT/DECR_CNT.
 	 */
 	DECR_CNT(&cnl->ref_cnt, &cnl->wc_var_lock);
-	if (memcmp(cnl->now_running, gtm_release_name, gtm_release_name_len + 1))
+	if (memcmp(cnl->now_running, ydb_release_name, ydb_release_name_len + 1))
 	{	/* VERMISMATCH condition. Possible only if DSE */
 		assert(dse_running);
 		vermismatch = TRUE;

--- a/sr_unix/gtmsecshr.c
+++ b/sr_unix/gtmsecshr.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -106,8 +109,8 @@ GBLREF	boolean_t		first_syslog;		/* Defined in util_output.c */
 GBLREF	char			gtm_dist[GTM_PATH_MAX];
 GBLREF	boolean_t		gtm_dist_ok_to_use;
 
-LITREF	char			gtm_release_name[];
-LITREF	int4			gtm_release_name_len;
+LITREF	char			ydb_release_name[];
+LITREF	int4			ydb_release_name_len;
 
 static	volatile int		gtmsecshr_timer_popped;
 static	int			gtmsecshr_socket_dir_len;
@@ -519,10 +522,10 @@ void gtmsecshr_init(char_ptr_t argv[], char **rundir, int *rundir_len)
 	/* Create communication key used in all gtmsecshr messages. Key's purpose is to eliminate cross-version
 	 * communication issues.
 	 */
-	STR_HASH((char *)gtm_release_name, gtm_release_name_len, TREF(gtmsecshr_comkey), 0);
+	STR_HASH((char *)ydb_release_name, ydb_release_name_len, TREF(gtmsecshr_comkey), 0);
 	/* Initialization complete */
 	send_msg_csa(CSA_ARG(NULL) VARLSTCNT(7) ERR_GTMSECSHRDMNSTARTED, 5,
-		gtmsecshr_key, gtm_release_name_len, gtm_release_name, *rundir_len, *rundir);
+		gtmsecshr_key, ydb_release_name_len, ydb_release_name, *rundir_len, *rundir);
 	return;
 }
 

--- a/sr_unix/gvcst_init_sysops.c
+++ b/sr_unix/gvcst_init_sysops.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -159,7 +162,7 @@ MBSTART {								\
 #define GTM_ATTACH_SHM_AND_CHECK_VERS(VERMISMATCH, SHM_SETUP_OK)								\
 MBSTART {															\
 	GTM_ATTACH_SHM;														\
-	/* The following checks for GDS_LABEL_GENERIC and  gtm_release_name ensure that the shared memory under consideration	\
+	/* The following checks for GDS_LABEL_GENERIC and  ydb_release_name ensure that the shared memory under consideration	\
 	 * is valid.  If shared memory is already initialized, do VERMISMATCH check BEFORE referencing any other fields in	\
 	 * shared memory.													\
 	 */															\
@@ -167,7 +170,7 @@ MBSTART {															\
 	SHM_SETUP_OK = FALSE;													\
 	if (!MEMCMP_LIT(csa->nl->label, GDS_LABEL_GENERIC))									\
 	{															\
-		if (memcmp(csa->nl->now_running, gtm_release_name, gtm_release_name_len + 1))					\
+		if (memcmp(csa->nl->now_running, ydb_release_name, ydb_release_name_len + 1))					\
 		{	/* Copy csa->nl->now_running into a local variable before passing to rts_error due to the following	\
 			 * issue:												\
 			 * In VMS, a call to rts_error copies only the error message and its arguments (as pointers) and	\
@@ -195,7 +198,7 @@ MBSTART {														\
 	if (!vermismatch_already_printed)										\
 	{														\
 		vermismatch_already_printed = TRUE;									\
-		RTS_ERROR(VARLSTCNT(8) ERR_VERMISMATCH, 6, DB_LEN_STR(reg), gtm_release_name_len, gtm_release_name,	\
+		RTS_ERROR(VARLSTCNT(8) ERR_VERMISMATCH, 6, DB_LEN_STR(reg), ydb_release_name_len, ydb_release_name,	\
 			  LEN_AND_STR(now_running));									\
 	}														\
 } MBEND
@@ -372,8 +375,8 @@ GBLREF	boolean_t		pool_init;
 GBLREF	int 	mutex_sock_fd;
 #endif
 
-LITREF  char                    gtm_release_name[];
-LITREF  int4                    gtm_release_name_len;
+LITREF  char                    ydb_release_name[];
+LITREF  int4                    ydb_release_name_len;
 
 OS_PAGE_SIZE_DECLARE
 
@@ -1305,8 +1308,8 @@ int db_init(gd_region *reg, boolean_t ok_to_bypass)
 		shmpool_buff_init(reg);
 		SS_INFO_INIT(csa);
 		STRNCPY_STR(cnl->machine_name, machine_name, MAX_MCNAMELEN);				/* machine name */
-		assert(MAX_REL_NAME > gtm_release_name_len);
-		memcpy(cnl->now_running, gtm_release_name, gtm_release_name_len + 1);	/* GT.M release name */
+		assert(MAX_REL_NAME > ydb_release_name_len);
+		memcpy(cnl->now_running, ydb_release_name, ydb_release_name_len + 1);		/* YottaDB release name */
 		memcpy(cnl->label, GDS_LABEL, GDS_LABEL_SZ - 1);				/* GDS label */
 		memcpy(cnl->fname, reg->dyn.addr->fname, reg->dyn.addr->fname_len);		/* database filename */
 		cnl->creation_date_time4 = csd->creation_time4;

--- a/sr_unix/incr_link.c
+++ b/sr_unix/incr_link.c
@@ -120,9 +120,6 @@ GBLDEF int		total_length;
 GBLDEF int		text_counter;
 #endif
 
-LITREF char		gtm_release_name[];
-LITREF int4		gtm_release_name_len;
-
 typedef struct	res_list_struct
 {
 	struct res_list_struct	*next,

--- a/sr_unix/jnlpool_init.c
+++ b/sr_unix/jnlpool_init.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -85,8 +88,8 @@ GBLREF	gd_addr					*gd_header;
 GBLREF	uint4	is_updhelper;
 #endif
 
-LITREF	char			gtm_release_name[];
-LITREF	int4			gtm_release_name_len;
+LITREF	char			ydb_release_name[];
+LITREF	int4			ydb_release_name_len;
 
 error_def(ERR_ACTIVATEFAIL);
 error_def(ERR_JNLPOOLBADSLOT);
@@ -949,7 +952,7 @@ void jnlpool_init(jnlpool_user pool_user, boolean_t gtmsource_startup, boolean_t
 		memcpy(jnlpool_ctl->jnlpool_id.instfilename, seg->fname, seg->fname_len);
 		jnlpool_ctl->jnlpool_id.instfilename[seg->fname_len] = '\0';
 		memcpy(jnlpool_ctl->jnlpool_id.label, GDS_RPL_LABEL, GDS_LABEL_SZ);
-		memcpy(jnlpool_ctl->jnlpool_id.now_running, gtm_release_name, gtm_release_name_len + 1);
+		memcpy(jnlpool_ctl->jnlpool_id.now_running, ydb_release_name, ydb_release_name_len + 1);
 		assert(0 == (offsetof(jnlpool_ctl_struct, start_jnl_seqno) % 8));
 					/* ensure that start_jnl_seqno starts at an 8 byte boundary */
 		assert(0 == offsetof(jnlpool_ctl_struct, jnlpool_id));

--- a/sr_unix/list_file.c
+++ b/sr_unix/list_file.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -141,8 +144,8 @@ void list_cmd(void)
 }
 
 
-LITREF char gtm_release_name[];
-LITREF int4 gtm_release_name_len;
+LITREF char ydb_release_name[];
+LITREF int4 ydb_release_name_len;
 
 GBLREF char source_file_name[];
 GBLREF unsigned short source_name_len;
@@ -159,8 +162,8 @@ void list_head(bool newpage)
 		op_wtff();
 
 	head.mvtype = MV_STR;
-	head.str.addr = (char *)&gtm_release_name[0];
-	head.str.len = gtm_release_name_len;
+	head.str.addr = (char *)&ydb_release_name[0];
+	head.str.len = ydb_release_name_len;
 	op_write (&head);
 
 	op_wttab(col_2);

--- a/sr_unix/mu_rndwn_all.c
+++ b/sr_unix/mu_rndwn_all.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -96,8 +99,8 @@ GBLREF	semid_queue_elem	*keep_semids;
 GBLREF	uid_t			user_id;
 GBLREF	uint4			process_id;
 
-LITREF char             gtm_release_name[];
-LITREF int4             gtm_release_name_len;
+LITREF char             ydb_release_name[];
+LITREF int4             ydb_release_name_len;
 
 error_def(ERR_DBFILERR);
 error_def(ERR_MUFILRNDWNFL2);
@@ -452,7 +455,7 @@ boolean_t validate_replpool_shm_entry(shm_parms *parm_buff, replpool_id_ptr_t re
 			util_out_print("Cannot rundown replpool shmid = !UL as it has format !AD "
 				"created by !AD but this mupip is version and uses format !AD",
 				TRUE, shmid, GDS_LABEL_SZ - 1, replpool_id->label,
-				LEN_AND_STR(replpool_id->now_running), gtm_release_name_len, gtm_release_name,
+				LEN_AND_STR(replpool_id->now_running), ydb_release_name_len, ydb_release_name,
 				GDS_LABEL_SZ - 1, GDS_RPL_LABEL);
 			*exit_stat = ERR_MUNOTALLSEC;
 		}

--- a/sr_unix/mu_rndwn_file.c
+++ b/sr_unix/mu_rndwn_file.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -103,8 +106,8 @@ static boolean_t	sem_created;
 static boolean_t	no_shm_exists;
 static boolean_t	shm_status_confirmed;
 
-LITREF char             gtm_release_name[];
-LITREF int4             gtm_release_name_len;
+LITREF char             ydb_release_name[];
+LITREF int4             ydb_release_name_len;
 
 error_def(ERR_BADDBVER);
 error_def(ERR_DBFILERR);
@@ -942,9 +945,9 @@ boolean_t mu_rndwn_file(gd_region *reg, boolean_t standalone)
 	SEG_SHMATTACH(0, reg, udi, tsd, sem_created, udi->counter_acc_incremented);
 	assert(csa == cs_addrs);
 	csa->nl = cnl = (node_local_ptr_t)csa->db_addrs[0];
-	/* The following checks for GDS_LABEL_GENERIC, gtm_release_name, and cnl->glob_sec_init ensure that the
+	/* The following checks for GDS_LABEL_GENERIC, ydb_release_name, and cnl->glob_sec_init ensure that the
 	 * shared memory under consideration is valid.  First, since cnl->label is in the same place for every
-	 * version, a failing check means it is most likely NOT a GT.M created shared memory, so no attempt will be
+	 * version, a failing check means it is most likely NOT a YottaDB created shared memory, so no attempt will be
 	 * made to delete it. Next a successful match of the currently running release will guarantee that all fields in
 	 * the structure are where they're expected to be -- without this check the glob_sec_init check should not be done
 	 * as this field is at different offsets in different versions. Finally, we can check the glob_sec_init flag to
@@ -961,10 +964,10 @@ boolean_t mu_rndwn_file(gd_region *reg, boolean_t standalone)
 		is_gtm_shm = TRUE;
 		remove_shmid = TRUE;
 		memcpy(now_running, cnl->now_running, MAX_REL_NAME);
-		if (memcmp(now_running, gtm_release_name, gtm_release_name_len + 1))
+		if (memcmp(now_running, ydb_release_name, ydb_release_name_len + 1))
 		{
-			gtm_putmsg_csa(CSA_ARG(csa) VARLSTCNT(8) ERR_VERMISMATCH, 6, DB_LEN_STR(reg), gtm_release_name_len,
-				   gtm_release_name, LEN_AND_STR(now_running));
+			gtm_putmsg_csa(CSA_ARG(csa) VARLSTCNT(8) ERR_VERMISMATCH, 6, DB_LEN_STR(reg), ydb_release_name_len,
+				   ydb_release_name, LEN_AND_STR(now_running));
 			MU_RNDWN_FILE_CLNUP(reg, udi, tsd, sem_created, udi->counter_acc_incremented);
 			return FALSE;
 		}

--- a/sr_unix/mu_rndwn_replpool.c
+++ b/sr_unix/mu_rndwn_replpool.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -68,8 +71,8 @@ GBLREF	mur_opt_struct		mur_options;
 GBLREF	uint4			mutex_per_process_init_pid;
 GBLREF	uint4			process_id;
 
-LITREF char             	gtm_release_name[];
-LITREF int4             	gtm_release_name_len;
+LITREF char             	ydb_release_name[];
+LITREF int4             	ydb_release_name_len;
 
 error_def(ERR_REPLACCSEM);
 error_def(ERR_REPLINSTOPEN);
@@ -117,10 +120,10 @@ int     mu_rndwn_replpool2(replpool_identifier *replpool_id, repl_inst_hdr_ptr_t
 		DETACH(start_addr, shm_id, instfilename);
 		return -1;
 	}
-	if (memcmp(replpool_id->now_running, gtm_release_name, gtm_release_name_len + 1))
+	if (memcmp(replpool_id->now_running, ydb_release_name, ydb_release_name_len + 1))
 	{
 		util_out_print("Attempt to access with version !AD, while already using !AD for replpool segment (id = !UL)"
-				" belonging to replication instance !AD.", TRUE, gtm_release_name_len, gtm_release_name,
+				" belonging to replication instance !AD.", TRUE, ydb_release_name_len, ydb_release_name,
 				LEN_AND_STR(replpool_id->now_running), shm_id, LEN_AND_STR(instfilename));
 		DETACH(start_addr, shm_id, instfilename);
 		return -1;

--- a/sr_unix/recvpool_init.c
+++ b/sr_unix/recvpool_init.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2016 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -58,8 +61,8 @@ GBLREF	gd_region		*gv_cur_region;
 GBLREF	repl_conn_info_t	*this_side, *remote_side;
 GBLREF	int4			strm_index;
 
-LITREF	char			gtm_release_name[];
-LITREF	int4			gtm_release_name_len;
+LITREF	char			ydb_release_name[];
+LITREF	int4			ydb_release_name_len;
 
 error_def(ERR_NORECVPOOL);
 error_def(ERR_RECVPOOLSETUP);
@@ -344,7 +347,7 @@ void recvpool_init(recvpool_user pool_user, boolean_t gtmrecv_startup)
 		recvpool.recvpool_ctl->wrapped = FALSE;
 		memcpy( (char *)recvpool.recvpool_ctl->recvpool_id.instfilename, instfilename, full_len);
 		memcpy(recvpool.recvpool_ctl->recvpool_id.label, GDS_RPL_LABEL, GDS_LABEL_SZ);
-		memcpy(recvpool.recvpool_ctl->recvpool_id.now_running, gtm_release_name, gtm_release_name_len + 1);
+		memcpy(recvpool.recvpool_ctl->recvpool_id.now_running, ydb_release_name, ydb_release_name_len + 1);
 		assert(0 == offsetof(recvpool_ctl_struct, recvpool_id));
 					/* ensure that the pool identifier is at the top of the pool */
 		recvpool.recvpool_ctl->recvpool_id.pool_type = RECVPOOL_SEGMENT;

--- a/sr_unix/repl_inst_dump.c
+++ b/sr_unix/repl_inst_dump.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2006-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -141,7 +144,7 @@ void	repl_inst_dump_filehdr(repl_inst_hdr_ptr_t repl_instance)
 	assert(dstlen <= 3);
 	util_out_print( PREFIX_FILEHDR "Minor Version                                      !R3AD", TRUE, dstlen, dststr);
 
-	/* Assert that the endianness of the instance file matches the endianness of the GT.M version
+	/* Assert that the endianness of the instance file matches the endianness of the YottaDB version
 	 * as otherwise we would have errored out long before reaching here.
 	 */
 #	ifdef BIGENDIAN
@@ -570,7 +573,7 @@ void	repl_inst_dump_jnlpoolctl(jnlpool_ctl_ptr_t jnlpool_ctl)
 	}
 
 	PRINT_OFFSET_PREFIX(offsetof(replpool_identifier, now_running[0]), SIZEOF(jnlpool_ctl->jnlpool_id.now_running));
-	util_out_print( PREFIX_JNLPOOLCTL "GT.M Version            !R30AZ", TRUE, jnlpool_ctl->jnlpool_id.now_running);
+	util_out_print( PREFIX_JNLPOOLCTL "YottaDB Version         !R30AZ", TRUE, jnlpool_ctl->jnlpool_id.now_running);
 
 	PRINT_OFFSET_PREFIX(offsetof(replpool_identifier, instfilename[0]), SIZEOF(jnlpool_ctl->jnlpool_id.instfilename));
 	if (22 >= strlen(jnlpool_ctl->jnlpool_id.instfilename))

--- a/sr_unix/secshr_client.c
+++ b/sr_unix/secshr_client.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -71,8 +74,8 @@ GBLREF ipcs_mesg		db_ipcs;
 GBLREF char			gtm_dist[GTM_PATH_MAX];
 GBLREF boolean_t		gtm_dist_ok_to_use;
 
-LITREF char			gtm_release_name[];
-LITREF int4			gtm_release_name_len;
+LITREF char			ydb_release_name[];
+LITREF int4			ydb_release_name_len;
 LITREF gtmImageName		gtmImageNames[];
 
 static int			secshr_sem;
@@ -196,9 +199,7 @@ int send_mesg2gtmsecshr(unsigned int code, unsigned int id, char *path, int path
 				gtmImageNames[image_type].imageNameLen, gtmImageNames[image_type].imageName);
 	/* Create communication key (hash of release name) if it has not already been done */
 	if (0 == TREF(gtmsecshr_comkey))
-	{
-		STR_HASH((char *)gtm_release_name, gtm_release_name_len, TREF(gtmsecshr_comkey), 0);
-	}
+		STR_HASH((char *)ydb_release_name, ydb_release_name_len, TREF(gtmsecshr_comkey), 0);
 	timer_id = (TID)send_mesg2gtmsecshr;
 	if (!gtmsecshr_file_check_done)
 	{

--- a/sr_unix_cm/omi_prc_conn.c
+++ b/sr_unix_cm/omi_prc_conn.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2014 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2014 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -236,9 +239,9 @@ int omi_prc_conn(omi_conn *cptr, char *xend, char *buff, char *bend)
     cptr->xptr += ss_len.value;
 
 /*  Implementation ID (out) */
-    len = SIZEOF(GTM_RELEASE_NAME) - 1;
+    len = SIZEOF(YDB_RELEASE_NAME) - 1;
     OMI_SI_WRIT(len, bptr);
-    (void) memcpy(bptr, GTM_RELEASE_NAME, len);
+    (void) memcpy(bptr, YDB_RELEASE_NAME, len);
     bptr += len;
 /*  Server name (out) */
     OMI_SI_WRIT(0, bptr);

--- a/sr_x86_64/obj_filesp.c
+++ b/sr_x86_64/obj_filesp.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2007-2015 Fidelity National Information 	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -86,8 +89,8 @@ static char static_string_tbl[] = {
 
 #define SPACE_STRING_ALLOC_LEN  (SIZEOF(static_string_tbl) +    \
                                  SIZEOF(GTM_LANG) + 1 +         \
-                                 SIZEOF(GTM_PRODUCT) + 1 +      \
-                                 SIZEOF(GTM_RELEASE_NAME) + 1 + \
+                                 SIZEOF(YDB_PRODUCT) + 1 +      \
+                                 SIZEOF(YDB_RELEASE_NAME) + 1 + \
                                  SIZEOF(mident_fixed))
 
 /* Following constants has to be in sync with above static string array(static_string_tbl) */
@@ -98,9 +101,6 @@ static char static_string_tbl[] = {
 #define SEC_TEXT_INDX 1
 #define SEC_STRTAB_INDX 2
 #define SEC_SYMTAB_INDX 3
-
-LITREF char gtm_release_name[];
-LITREF int4 gtm_release_name_len;
 
 GBLREF mliteral 	literal_chain;
 GBLREF char 		source_file_name[];
@@ -160,11 +160,11 @@ void finish_object_file(void)
         strEntrySize = SIZEOF(GTM_LANG);
         memcpy((string_tbl + symIndex), GTM_LANG, strEntrySize);
         symIndex += strEntrySize;
-        strEntrySize = SIZEOF(GTM_PRODUCT);
-        memcpy((string_tbl + symIndex), GTM_PRODUCT, strEntrySize);
+        strEntrySize = SIZEOF(YDB_PRODUCT);
+        memcpy((string_tbl + symIndex), YDB_PRODUCT, strEntrySize);
         symIndex += strEntrySize;
-        strEntrySize = SIZEOF(GTM_RELEASE_NAME);
-        memcpy((string_tbl + symIndex), GTM_RELEASE_NAME, strEntrySize);
+        strEntrySize = SIZEOF(YDB_RELEASE_NAME);
+        memcpy((string_tbl + symIndex), YDB_RELEASE_NAME, strEntrySize);
 	symIndex += strEntrySize;
         gtm_obj_code = (char *)malloc(bufSize);
         /* At this point, we have only the GTM object written onto the file.


### PR DESCRIPTION

Release Note
-------------
A VERMISMATCH error now reports the YottaDB release # and not the GT.M release #.

Test
-----
* E_ALL run many times to ensure no regressions.

README
-------
Almost all usages of gtm_release_name were examined and changed to ydb_release_name.
The only place left was where we report $ZVERSION which does need to use gtm_release_name.
This meant that database shared memory created by a GT.M version cannot be attached to by a
YottaDB version even if both the versions have the same shared memory layout (because the
shared memory would have the GT.M version # stored whereas the YottaDB version expects the
YottaDB release # to be stored). Similarly, the jnlpool, receive pool and the object file
now have the YottaDB release # stored.