### PR TITLE
Disable fstack-protector for pro builds (helps reduce executable size…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,12 +43,10 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()
 
-# Enable YottaDB debug options unless directed not to enable them. Added to build without whitebox tests.
-set(YDB_ENABLE_DEBUG 1 CACHE BOOL "Enable YottaDB debug options")
-if(YDB_ENABLE_DEBUG)
-  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
-  set(CMAKE_ASM_FLAGS_DEBUG "${CMAKE_ASM_FLAGS_DEBUG} -Wa,--defsym,DEBUG=1")
-endif()
+# If CMAKE_BUILD_TYPE is set to Debug, then CMAKE_C_FLAGS_DEBUG variable contents will be added at the end of
+# CMAKE_C_FLAGS during compilation (likewise with CMAKE_ASM_FLAGS_DEBUG). Keep these debug variables defined and ready.
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
+set(CMAKE_ASM_FLAGS_DEBUG "${CMAKE_ASM_FLAGS_DEBUG} -Wa,--defsym,DEBUG=1")
 
 set(install_permissions_script
   OWNER_READ OWNER_EXECUTE OWNER_WRITE

--- a/sr_linux/platform.cmake
+++ b/sr_linux/platform.cmake
@@ -97,6 +97,15 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-maybe-uninitialized -Wno-char-subscript
 # But they are no-ops in case of a dbg build when optimization is turned off so we include them in all cmake builds.
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-defer-pop -fno-strict-aliasing -ffloat-store -fno-omit-frame-pointer")
 
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+	# Newer versions of Linux by default include -fstack-protector in gcc. This causes the build to slightly bloat
+	# in size. Avoid that for production builds of YottaDB.
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-stack-protector")
+else()
+	# In Debug builds though, keep stack-protection on for ALL functions.
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
+endif()
+
 add_definitions(
   #-DNOLIBGTMSHR #gt_cc_option_DBTABLD=-DNOLIBGTMSHR
   -D_GNU_SOURCE


### PR DESCRIPTION
…) but enable it for all functions explicitly for dbg builds