### PR TITLE
Revert "[YDB#66] [NARS1] [shabiel] Do not use -rdynamic for C link-time flags (default in cmake) as that bloats executable sizes unnecessarily"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,6 @@
 cmake_minimum_required(VERSION 2.8.5)
 project(YDB C ASM)
 
-# By default, cmake uses -rdynamic for C link-time flags. That is not needed here and bloats executable sizes unnecessarily.
-# So disable that by defining the link-time C flags to the null string.
-set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS  )
-
 # Max optimization level is -O2
 get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
 foreach(lang ${languages})


### PR DESCRIPTION

This reverts commit 29ac63a4000ce3cbbc4c57ffb8fef511eee49695. This is because at least mupip
currently does a dlopen() of shared libraries (e.g. libgtmtls.so) which in turn open shared libraries
(e.g. libgtmcryptutil.so) that in turn use symbols (e.g. "gtm_free") which need to be resolved
back in the mupip executable. And -rdynamic is needed to let that resolve fine.