### PR TITLE
[NARS1] [ksbhaskar] Enhancements to ydbinstall.sh --help to display the command for UTF-8 install; Fix GT.M version installdir

### DIFF
--- a/sr_unix/ydbinstall.sh
+++ b/sr_unix/ydbinstall.sh
@@ -134,11 +134,11 @@ help_exit()
     echo "version is defaulted from mumps file if one exists in the same directory as the installer"
     echo "This version must run as root."
     echo ""
-    echo "Example usages are (assumes latest YottaDB release is r1.10)"
-    echo "  ydbinstall.sh                              # installs latest YottaDB release (r1.10) at /usr/local/lib/yottadb/r110"
-    echo "  ydbinstall.sh --utf8 default               # installs YottaDB release r1.10 with added support for UTF-8"
-    echo "  ydbinstall.sh --installdir /tmp/r110 r1.10 # installs YottaDB r1.10 at /tmp/r110"
-    echo "  ydbinstall.sh --gtm V6.3-002               # installs GT.M V6.3-002 at /usr/local/lib/fis-gtm/V6.3-002_x86_64"
+    echo "Example usages are (assumes latest YottaDB release is r1.10 and latest GT.M version is V6.3-002)"
+    echo "  ydbinstall.sh                          # installs latest YottaDB release (r1.10) at /usr/local/lib/yottadb/r110"
+    echo "  ydbinstall.sh --utf8 default           # installs YottaDB release r1.10 with added support for UTF-8"
+    echo "  ydbinstall.sh --installdir /r110 r1.10 # installs YottaDB r1.10 at /r110"
+    echo "  ydbinstall.sh --gtm                    # installs latest GT.M version (V6.3-002) at /usr/local/lib/fis-gtm/V6.3-002_x86_64"
     echo ""
     exit 1
 }

--- a/sr_unix/ydbinstall.sh
+++ b/sr_unix/ydbinstall.sh
@@ -134,10 +134,11 @@ help_exit()
     echo "version is defaulted from mumps file if one exists in the same directory as the installer"
     echo "This version must run as root."
     echo ""
-    echo "Example usages are"
-    echo "  ydbinstall.sh                              # installs latest YottaDB version (r1.10) at /usr/local/lib/yottadb/r110"
-    echo "  ydbinstall.sh --installdir /tmp/r110 r1.00 # installs YottaDB r1.00 at /tmp/r110"
-    echo "  ydbinstall.sh --gtm V6.3-002               # installs GT.M V6.3-002"
+    echo "Example usages are (assumes latest YottaDB release is r1.10)"
+    echo "  ydbinstall.sh                              # installs latest YottaDB release (r1.10) at /usr/local/lib/yottadb/r110"
+    echo "  ydbinstall.sh --utf8 default               # installs YottaDB release r1.10 with added support for UTF-8"
+    echo "  ydbinstall.sh --installdir /tmp/r110 r1.10 # installs YottaDB r1.10 at /tmp/r110"
+    echo "  ydbinstall.sh --gtm V6.3-002               # installs GT.M V6.3-002 at /usr/local/lib/fis-gtm/V6.3-002_x86_64"
     echo ""
     exit 1
 }
@@ -499,7 +500,7 @@ if [ -z "$ydb_installdir" ] ; then
     if [ "N" = "$gtm_gtm" ] ; then
          ydbver=`echo $ydb_version | tr '[A-Z]' '[a-z]' | tr -d '.-'`
          ydb_installdir=/usr/local/lib/yottadb/${ydbver}
-    else ydb_installdir=/usr/local/lib/fis-gtm/${gtm_version}_${gtm_install_flavor}
+    else ydb_installdir=/usr/local/lib/fis-gtm/${ydb_version}_${gtm_install_flavor}
     fi
 fi
 if [ -d "$ydb_installdir" -a "Y" != "$gtm_overwrite_existing" ] ; then


### PR DESCRIPTION

* The example usages (displayed by running ydbinstall.sh --help) are now enhanced.
* One displayed example (ydbinstall.sh --gtm V6.3-002) installed GT.M at /usr/local/lib/fis-gtm/_x86_64
	and is now fixed to install at /usr/local/lib/fis-gtm/V6.3-002_x86_64