### PR TITLE
During utf8 install, avoid soft link recursion in $gtm_dist/utf8/utf8

### DIFF
--- a/sr_unix/configure.gtc
+++ b/sr_unix/configure.gtc
@@ -51,7 +51,7 @@ fi
 # which exist in both directories.
 
 if [ -d utf8 ]; then
-	(cd utf8; ln -s ../* . 2> /dev/null; exit 0)
+	(cd utf8; ln -s ../* . 2> /dev/null; rm utf8; exit 0)
 fi
 
 # Native shared library extension.


### PR DESCRIPTION
Having a utf8 filename in $gtm_dist/utf8 soft link back to $gtm_dist is a recipe for soft link recursion and can cause operational issues (e.g. backups). So avoid that.