### PR TITLE
[#100] Do not treat fractional timeouts with more than 3 digits after the decimal point as a 2Gi msec timeout

### DIFF
--- a/sr_port/op_open.c
+++ b/sr_port/op_open.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -41,6 +44,7 @@
 #ifdef DEBUG
 #include "have_crit.h"		/* for the TPNOTACID_CHECK macro */
 #endif
+#include "mvalconv.h"
 
 GBLREF uint4		dollar_trestart;
 GBLREF io_log_name	*io_root_log_name;

--- a/sr_port/op_read.c
+++ b/sr_port/op_read.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -39,6 +42,7 @@
 #ifdef DEBUG
 #include "have_crit.h"		/* for the TPNOTACID_CHECK macro */
 #endif
+#include "mvalconv.h"
 
 GBLREF io_pair		io_curr_device;
 GBLREF io_desc		*active_device;

--- a/sr_port/op_readfl.c
+++ b/sr_port/op_readfl.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -37,6 +40,7 @@
 #ifdef DEBUG
 #include "have_crit.h"		/* for the TPNOTACID_CHECK macro */
 #endif
+#include "mvalconv.h"
 
 GBLREF boolean_t	gtm_utf8_mode;
 GBLREF io_pair		io_curr_device;


### PR DESCRIPTION
Basically, a READ Y:.0001 hangs indefinitely. But a READ Y:.001 times out correctly.
This is an issue introduced in GTM-5250 as part of GT.M V6.3-002.

The MV_FORCE_MSTIMEOUT macro is what converted the fractional timeout into an integer # of milliseconds.
This worked correctly if the mvtype of the mval holding the timeout value is MV_INT (which is the case
even for fractions upto 3 decimal digits). But for fractions greater than 3 decimal digits, the mvtype
would not be MV_INT but instead MV_NM and in that case, the macro was incorrectly setting the timeout
to be MAXPOSINST4 (2Gi) milliseconds (~ 24 days). This is now fixed by doing a mval2double() call to
determine the real value and converting that into milliseconds and capping that timeout with MAXPOSINT4.

The affected commands are JOB, LOCK, OPEN, READ. Additionally, WRITE /WAIT, WRITE /LISTEN, WRITE /ACCEPT
and WRITE /TLS (all of which are applicable only to the socket device type) are affected.