### PR TITLE
[#59] Fix a few issues (in a prior #59 commit) exposed by the java test

### DIFF
--- a/sr_unix/gtmshr_symbols.exp
+++ b/sr_unix/gtmshr_symbols.exp
@@ -6,6 +6,10 @@ ydb_cij
 ydb_cip
 ydb_exit
 ydb_zstatus
+gtm_jinit
+gtm_exit
+gtm_cij
+gtm_zstatus
 gtm_hiber_start
 gtm_hiber_start_wait_any
 gtm_start_timer

--- a/sr_unix/gtmxc_types.h
+++ b/sr_unix/gtmxc_types.h
@@ -12,7 +12,7 @@
 
 /* The current version of this header file is now called libyottadb.h. This header file contains those
  * definitions (based on the base types defined in libyottadb.h) that enable compatibility with exiting
- * GT.M shops supporting the gtm_* types and routines and even the deprecated xc_* types. This allows 
+ * GT.M shops supporting the gtm_* types and routines and even the deprecated xc_* types. This allows
  * shops used to GT.M to "just work" using previously supported type/routine names.
  */
 #ifndef GTMXC_TYPES_H
@@ -56,6 +56,19 @@ typedef ydb_double_t		gtm_jdouble_t;
 typedef ydb_char_t		gtm_jstring_t;
 typedef ydb_char_t		gtm_jbyte_array_t;
 typedef ydb_char_t		gtm_jbig_decimal_t;
+
+/* The java plug-in has some very direct references to some of these routines that
+ * cannot be changed by the pre-processor so for now, we have some stub routines
+ * that take care of the translation. These routines are exported along with their
+ * ydb_* variants.
+ */
+#ifdef GTM_PTHREAD
+ydb_status_t 	gtm_jinit(void);
+#endif
+ydb_status_t 	gtm_exit(void);
+ydb_status_t	gtm_cij(const char *c_rtn_name, char **arg_blob, int count, int *arg_types, unsigned int *io_vars_mask,
+		unsigned int *has_ret_value);
+void 		gtm_zstatus(char* msg, int len);
 
 /* Define backward compatibility routine name defines for GT.M entry points */
 #define gtm_ci				ydb_ci

--- a/sr_unix/op_fnfgncal.c
+++ b/sr_unix/op_fnfgncal.c
@@ -758,8 +758,8 @@ void op_fnfgncal(uint4 n_mvals, mval *dst, mval *package, mval *extref, uint4 ma
 	/* Entry not found */
 	if ((NULL == entry_ptr) || (NULL == entry_ptr->fcn))
 		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_ZCRTENOTF, 2, extref->str.len, extref->str.addr);
-	/* Detect a call-out to Java. */
-	if ((NULL != entry_ptr->call_name.addr) && !strncmp(entry_ptr->call_name.addr, "ydb_xcj", 7))
+	/* Detect a call-out to Java. The java plugin still has references to "gtm_xcj" (not "ydb_xcj") hence the below check. */
+	if ((NULL != entry_ptr->call_name.addr) && !strncmp(entry_ptr->call_name.addr, "gtm_xcj", 7))
 	{
 		java = TRUE;
 		argcnt -= 2;


### PR DESCRIPTION
Below are the issues.

1) Various modules : The prior commit changed names of functions to have ydb_ prefix instead
   of the gtm_ prefix. But the latest java plugin has the function names with the gtm_ prefix
   hardcoded and since we do not want to maintain the java plugin at this point in time,
   we need to provide function names with both the ydb_ and gtm_ prefix.

2) gtmci.c : The prior commit had added a call to op_exfunret() in the ydb_cij() function.
   But this was in the wrong place (should have been in the "if" block instead of the "else"
   block). This is now fixed like how it is in the ydb_ci_exec() function.

3) op_fnfgncal.c : The prior commit had changed the name "gtm_xcj" to be "ydb_xcj". But the
   java plugin is the one that defines this function and, again since we want to avoid having
   to maintain the java plugin at this point in time, the name check done here is reverted to
   use "gtm_xcj".

The java test passes after these fixes.