### PR TITLE
[#33] Fix code to let MIXIMAGE error (recently introduced) be issued when appropriate

### DIFF
--- a/sr_port/gtm_threadgbl_init.c
+++ b/sr_port/gtm_threadgbl_init.c
@@ -183,16 +183,17 @@ void gtm_threadgbl_init(void)
 {
 	void	*lcl_gtm_threadgbl;
 
+	if (NULL != gtm_threadgbl)
+	{	/* Has already been initialized. Return right away. Caller will later invoke "common_startup_init"
+		 * which will issue MIXIMAGE error.
+		 */
+		return;
+	}
 	if (SIZEOF(gtm_threadgbl_true_t) != size_gtm_threadgbl_struct)
 	{	/* Size mismatch with gtm_threadgbl_deftypes.h - no error handling yet available so do
 		 * the best we can.
 		 */
 		FPRINTF(stderr, "GTM-F-GTMASSERT gtm_threadgbl_true_t and gtm_threadgbl_t are different sizes\n");
-		EXIT(ERR_GTMASSERT);
-	}
-	if (NULL != gtm_threadgbl)
-	{	/* has already been initialized - don't re-init */
-		FPRINTF(stderr, "GTM-F-GTMASSERT gtm_threadgbl is already initialized\n");
 		EXIT(ERR_GTMASSERT);
 	}
 	gtm_threadgbl = lcl_gtm_threadgbl = malloc(size_gtm_threadgbl_struct);

--- a/sr_unix_cm/gtcm_server_main.c
+++ b/sr_unix_cm/gtcm_server_main.c
@@ -72,7 +72,6 @@ int gtcm_server_main(int argc, char_ptr_t argv[], char **envp)
 	DCL_THREADGBL_ACCESS;
 
 	GTM_THREADGBL_INIT;
-	ctxt = NULL;
 	common_startup_init(GTCM_SERVER_IMAGE, NULL);	/* The GTCM server does not have any command tables
 							 * so pass command array as NULL.
 							 */
@@ -85,7 +84,6 @@ int gtcm_server_main(int argc, char_ptr_t argv[], char **envp)
 	err_init(gtcm_exit_ch);
 	gtm_chk_dist(argv[0]);
 	omi_errno = OMI_ER_NO_ERROR;
-	ctxt = ctxt;
 	ESTABLISH_RET(omi_dbms_ch, -1);	/* any return value to signify error return */
 	gtcm_init(argc, argv);
 	gtcm_ltime = gtcm_stime = (int4)time(0);


### PR DESCRIPTION
While trying to check whether the MIXIMAGE error (introduced as part of a recent #33 commit)
is issued correctly, a couple of code issues were identified.

1) gtm_threadgbl_init() is invoked by the GTM_THREADGBL_INIT macro and that is invoked only
   once per image (i.e. once in mumps, once in mupip etc.). And so it had a check that
   gtm_threadgbl be NULL and issued an error otherwise. But it is possible in case the process
   has already loaded an image and is attempting to load another image that gtm_threadgbl is
   non-NULL. This is a case where a MIXIMAGE error is about to be issued by common_startup_init()
   once we return from this function. So this check is now changed so we return if non-NULL.

2) gtcm_server_main() set "ctxt" global variable to NULL at function entry. This caused an
   error issued in "common_startup_init" to SIG-11 because this global variable is used by
   the rts_error scheme as part of maintaining the condition-handler stack. It is not clear why
   the NULL set is needed so that is now removed. This way, if a MIXIMAGE error is going to be
   issued, "ctxt" would already be non-NULL (as part of the err_init() done for the first image
   that was loaded). Also, a redundant "ctxt = ctxt" statement a little later in this function
   is now removed.