### PR TITLE
[#109] New ydb_repl_filter_timeout env var to control the timeout bef…

### DIFF
--- a/sr_port/gbldefs.c
+++ b/sr_port/gbldefs.c
@@ -1193,7 +1193,7 @@ GBLDEF	void		(*mupip_exit_fp)(int4 errnum);	/* Function pointer to mupip_exit() 
 							 */
 GBLDEF	CLI_ENTRY	*cmd_ary;	/* Pointer to command table for MUMPS/DSE/LKE etc. */
 
-/* GT.CM OMI related global variables */
+/* Begin -- GT.CM OMI related global variables */
 GBLDEF	bool		neterr_pending;
 GBLDEF	int4		omi_bsent = 0;
 GBLDEF	int		psock = -1;		/* pinging socket */
@@ -1221,3 +1221,8 @@ GBLDEF	int		conn_timeout = TIMEOUT_INTERVAL;
 GBLDEF	int		history = 0;
 /* image_id....allows you to determine info about the server by using the strings command, or running dbx */
 GBLDEF	char		image_id[256]= "image_id";
+/* End -- GT.CM OMI related global variables */
+
+GBLDEF	int		ydb_repl_filter_timeout;	/* # of seconds that source server waits before issuing FILTERTIMEDOUT
+							 * error if it sees no response from the external filter program.
+							 */

--- a/sr_port/repl_filter.c
+++ b/sr_port/repl_filter.c
@@ -822,9 +822,9 @@ STATICFNDEF int repl_filter_recv_line(char *line, int *line_len, int max_line_le
 					}
 					assert(half_timeout_done);
 					/* GET_C_STACK_FROM_SCRIPT calls gtm_system(BYPASSOK) with interrupts deferred. If the
-					 * stack trace takes more than REPL_FILTER_HALF_TIMEOUT seconds, the next timeout interrupt
-					 * will be deferred until gtm_system(BYPASSOK) returns. At which point timedout will be
-					 * TRUE and there will be no signal received by GT.M to interrupt the blocking read() at
+					 * stack trace takes more than REPL_FILTER_HALF_TIMEOUT seconds, the next timeout
+					 * interrupt is deferred until gtm_system(BYPASSOK) returns. At which point timedout is
+					 * TRUE and there is no signal received by GT.M to interrupt the blocking read() at
 					 * the begining of the loop.  So we handle the timeout now and skip the second stack trace.
 					 */
 					if (half_timeout_done && timedout)

--- a/sr_port/repl_filter.c
+++ b/sr_port/repl_filter.c
@@ -1340,7 +1340,7 @@ int jnl_v17TOv24(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 		assert(SIZEOF(token_seq_t) == SIZEOF(seq_num));
 		t_len = (JREC_PREFIX_SIZE + SIZEOF(token_seq_t));
 		memcpy(cb, jb, t_len);
-		((jrec_prefix *)cb)->forwptr = conv_reclen; /* forwptr will be different between V17 and V24 due to new length */
+		((jrec_prefix *)cb)->forwptr = conv_reclen; /* forwptr is different between V17 and V24 due to new length */
 		cb += t_len;
 		jb += t_len;
 		/* Initialize 8-byte "strm_seqno" (common to TCOM/NULL/SET/KILL/ZKILL/ZTRIG jnl records) to 0 */
@@ -1442,7 +1442,7 @@ int jnl_v24TOv17(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 			assert(SIZEOF(token_seq_t) == SIZEOF(seq_num));
 			t_len = (JREC_PREFIX_SIZE + SIZEOF(token_seq_t));
 			memcpy(cb, jb, t_len);
-			((jrec_prefix *)cb)->forwptr = conv_reclen; /* forwptr will be different between V17 and V24 */
+			((jrec_prefix *)cb)->forwptr = conv_reclen; /* forwptr is different between V17 and V24 */
 			cb += t_len;
 			jb += t_len;
 			if (is_set_kill_zkill_ztrig)
@@ -1591,7 +1591,7 @@ int jnl_v19TOv24(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 	QWASSIGN(this_upd_seqno, seq_num_zero);
 	promote_uupd_to_tupd = FALSE;
 	assert(is_rcvr_server);
-	/* Since this filter function will be invoked only on the receiver side, the check for whether the receiver
+	/* Since this filter function is invoked only on the receiver side, the check for whether the receiver
 	 * supports triggers is equal to checking whether the LOCAL side supports triggers.
 	 */
 	receiver_supports_triggers = LOCAL_TRIGGER_SUPPORT;
@@ -1784,7 +1784,7 @@ int jnl_v24TOv19(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 	promote_uupd_to_tupd = FALSE;
 	hasht_seen = FALSE;
 	assert(is_src_server);
-	/* Since this filter function will be invoked only on the source side, the check for whether the receiver
+	/* Since this filter function is invoked only on the source side, the check for whether the receiver
 	 * supports triggers is equal to checking whether the REMOTE side supports triggers.
 	 */
 	receiver_supports_triggers = REMOTE_TRIGGER_SUPPORT;
@@ -1825,7 +1825,7 @@ int jnl_v24TOv19(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 			assert(SIZEOF(token_seq_t) == SIZEOF(seq_num));
 			t_len = (JREC_PREFIX_SIZE + SIZEOF(token_seq_t));
 			memcpy(cb, jb, t_len);
-			((jrec_prefix *)cb)->forwptr = conv_reclen; /* forwptr will be different between V19 and V24 */
+			((jrec_prefix *)cb)->forwptr = conv_reclen; /* forwptr is different between V19 and V24 */
 			assert((jb + t_len - jstart) == OFFSETOF(struct_jrec_upd, strm_seqno));
 			if (IS_SET_KILL_ZKILL_ZTWORM(rectype))
 			{
@@ -1974,7 +1974,7 @@ int jnl_v21TOv24(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 	QWASSIGN(this_upd_seqno, seq_num_zero);
 	promote_uupd_to_tupd = FALSE;
 	assert(is_rcvr_server);
-	/* Since this filter function will be invoked only on the receiver side, the check for whether the receiver
+	/* Since this filter function is invoked only on the receiver side, the check for whether the receiver
 	 * supports triggers is equal to checking whether the LOCAL side supports triggers.
 	 */
 	receiver_supports_triggers = LOCAL_TRIGGER_SUPPORT;
@@ -2167,7 +2167,7 @@ int jnl_v24TOv21(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 	QWASSIGN(this_upd_seqno, seq_num_zero);
 	promote_uupd_to_tupd = FALSE;
 	assert(is_src_server);
-	/* Since this filter function will be invoked only on the source side, the check for whether the receiver
+	/* Since this filter function is invoked only on the source side, the check for whether the receiver
 	 * supports triggers is equal to checking whether the REMOTE side supports triggers.
 	 */
 	receiver_supports_triggers = REMOTE_TRIGGER_SUPPORT;
@@ -2209,7 +2209,7 @@ int jnl_v24TOv21(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 			assert(SIZEOF(token_seq_t) == SIZEOF(seq_num));
 			t_len = (JREC_PREFIX_SIZE + SIZEOF(token_seq_t));
 			memcpy(cb, jb, t_len);
-			((jrec_prefix *)cb)->forwptr = conv_reclen; /* forwptr will be different between V21 and V24 */
+			((jrec_prefix *)cb)->forwptr = conv_reclen; /* forwptr is different between V21 and V24 */
 			assert((jb + t_len - jstart) == OFFSETOF(struct_jrec_upd, strm_seqno));
 			if (IS_SET_KILL_ZKILL_ZTWORM_ZTRIG(rectype))
 			{
@@ -2355,7 +2355,7 @@ int jnl_v22TOv24(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 	this_upd_seqno = seq_num_zero;
 	promote_uupd_to_tupd = FALSE;
 	assert(is_rcvr_server);
-	/* Since this filter function will be invoked only on the receiver side, the check for whether the receiver
+	/* Since this filter function is invoked only on the receiver side, the check for whether the receiver
 	 * supports triggers is equal to checking whether the LOCAL side supports triggers.
 	 */
 	receiver_supports_triggers = LOCAL_TRIGGER_SUPPORT;
@@ -2527,7 +2527,7 @@ int jnl_v24TOv22(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 	this_upd_seqno = seq_num_zero;
 	promote_uupd_to_tupd = FALSE;
 	assert(is_src_server);
-	/* Since this filter function will be invoked only on the source side, the check for whether the receiver
+	/* Since this filter function is invoked only on the source side, the check for whether the receiver
 	 * supports triggers is equal to checking whether the REMOTE side supports triggers.
 	 */
 	receiver_supports_triggers = REMOTE_TRIGGER_SUPPORT;
@@ -2704,7 +2704,7 @@ int jnl_v24TOv24(uchar_ptr_t jnl_buff, uint4 *jnl_len, uchar_ptr_t conv_buff, ui
 	promote_uupd_to_tupd = FALSE;
 	/* Since filter format V24 corresponds to journal formats V24, V25, or v26, in case of a V24 source and V2{5,6} receiver,
 	 * the source server will not do any filter transformations (because receiver jnl ver is higher). This means
-	 * jnl_v24TOv24 filter conversion function will be invoked on the receiver side to do V24 to V2{5,6} jnl format conversion.
+	 * jnl_v24TOv24 filter conversion function is invoked on the receiver side to do V24 to V2{5,6} jnl format conversion.
 	 * Therefore we cannot do an assert(is_src_server) which we otherwise would have had in case the latest filter
 	 * version corresponds to only ONE journal version.
 	 *	assert(is_src_server);

--- a/sr_port/repl_filter.h
+++ b/sr_port/repl_filter.h
@@ -42,6 +42,10 @@
 #define	GTMNULL_TO_STDNULL_COLL		1
 #define	STDNULL_TO_GTMNULL_COLL		2
 
+#define	REPL_FILTER_TIMEOUT_MIN		32	/* in seconds */
+#define	REPL_FILTER_TIMEOUT_DEF		64	/* in seconds */
+#define	REPL_FILTER_TIMEOUT_MAX		131072	/* 2^17 seconds */
+
 typedef int (*intlfltr_t)(uchar_ptr_t, uint4 *, uchar_ptr_t, uint4 *, uint4);
 
 /* The following is the list of filter-format version number versus the earliest GT.M version number that used it.

--- a/sr_unix/gtm_logicals.h
+++ b/sr_unix/gtm_logicals.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -152,4 +155,7 @@
 #define GTM_LOCALE			"$gtm_locale"
 #define GTM_UTFCGR_STRINGS		"$gtm_utfcgr_strings"
 #define GTM_UTFCGR_STRING_GROUPS	"$gtm_utfcgr_string_groups"
+
+/* YottaDB specified variables */
+#define	YDB_REPL_FILTER_TIMEOUT		"$ydb_repl_filter_timeout"
 


### PR DESCRIPTION
…ore a FILTERTIMEDOUT error is issued by the source server

Release Note
-------------
The environment variable ydb_repl_filter_timeout can be set to an integer value indicating the timeout (in seconds) that the replication source server sets for a response from the external filter program. A value less than 32 would be treated as if 32 was specified. A value greater than 131072 (2**17) would be treated as if 131072 was specified. The default value of the timeout (if env var is not specified) is 64 seconds. This provides the user a way to avoid seeing FILTERTIMEDOUT errors from the source server on relatively slower systems. YottaDB r1.10 and prior versions used to set the timeout to a hardcoded value of 64 after which a FILTERTIMEDOUT error was issued in the source server log and the external filter program was stopped.