### PR TITLE
caller_id now works in YottaDB for ARM Linux (just like it does on YottaDB for x86_64 Linux)

### DIFF
--- a/sr_linux/platform.cmake
+++ b/sr_linux/platform.cmake
@@ -108,6 +108,10 @@ else()
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
 endif()
 
+# On ARM Linux, gcc by default does not include -funwind-tables whereas it does on x86_64 Linux.
+# This is needed to get backtrace() (used by caller_id.c etc.) working correctly.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funwind-tables")
+
 add_definitions(
   #-DNOLIBGTMSHR #gt_cc_option_DBTABLD=-DNOLIBGTMSHR
   -D_GNU_SOURCE


### PR DESCRIPTION
It was observed that caller_id.c did not record the caller function information in debug arrays
(e.g. cs_addrs->nl->crit_ops_array[].call_from) in YottaDB for ARM Linux whereas it did in YottaDB
for x86_64 Linux. Turns out this was because backtrace() returned 0 on ARM Linux.  And that in
turn was due to gcc default options not including -funwind-tables.  This is now fixed by adding
this option explicitly for all platforms (including x86_64 Linux) in case a future version of
gcc there removes this flag by default.  After the change to add this compiler flag, backtrace()
returns a non-zero value and caller_id now works.

Since this is noticeable only in debug builds of YottaDB, this does not have a separate issue#.