### PR TITLE
[#122] Fix various issues with MUPIP JOURNAL ROLLBACK in handling NULL type of journal records

### DIFF
--- a/sr_port/mur_forward_play_cur_jrec.c
+++ b/sr_port/mur_forward_play_cur_jrec.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2010-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -175,8 +178,11 @@ uint4	mur_forward_play_cur_jrec(reg_ctl_list *rctl)
 	recstat = process_losttn ? LOST_TN : GOOD_TN;
 	status = SS_NORMAL;
 	if (FENCE_NONE != mur_options.fences)
-	{
-		if (IS_FENCED(rectype))
+	{	/* Note that a JRT_NULL record could also be part of a TP transaction
+		 * (see mur_back_process.c comment describing "jnl_phase2_salvage".
+		 * So check for that too when checking for fenced record types.
+		 */
+		if (IS_FENCED(rectype) || (JRT_NULL == rectype))
 		{
 			assert(rec_token_seq);
 #			ifdef DEBUG

--- a/sr_unix/jnlext_merge_sort_prepare.c
+++ b/sr_unix/jnlext_merge_sort_prepare.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2015 Fidelity National Information		*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -48,7 +51,7 @@ void jnlext_merge_sort_prepare(jnl_ctl_list *jctl, jnl_record *rec, enum broken_
 	{
 		assert(rec == rctl->mur_desc->jnlrec);
 		rectype = (enum jnl_record_type)rec->prefix.jrec_type;
-		is_logical_rec = (IS_SET_KILL_ZKILL_ZTWORM_LGTRIG_ZTRIG(rectype) || IS_COM(rectype));
+		is_logical_rec = (IS_SET_KILL_ZKILL_ZTWORM_LGTRIG_ZTRIG(rectype) || IS_COM(rectype) || (JRT_NULL == rectype));
 		need_new_elem = (is_logical_rec || (NULL == jext_rec) || rctl->last_jext_logical_rec[recstat]
 				|| (jext_rec->time != rec->prefix.time));
 		assert(need_new_elem || (NULL != rctl->jnlext_multi_list[recstat]));


### PR DESCRIPTION
mur_back_process.c : It is possible a NULL record got written on behalf of a TP transaction's records in one region
(by "jnl_phase2_salvage", when a process gets abnormally killed) but some regions of the same TP transaction have
those records in tact. In this scenario, mur_back_process.c currently issues a DUPTOKEN error in pro and an assert
failure in dbg. This is now fixed to treat all records of this transaction across multiple regions (NULL or non-NULL
type of records) as belonging to the same transaction and not issue a DUPTOKEN error.

mur_forward_play_cur_jrec.c : Ensure a NULL record written on behalf of a TP transaction's records in one region
gets treated as a broken transaction and ends up in the broken transaction file).

jnlext_merge_sort_prepare.c : Use jnl seqno as token for NULL journal record (instead of 0). This ensures NULL
records get extracted in seqno order in the journal extract, broken transaction and lost transaction files.