### PR TITLE
Get YottaDB builds working on Arch linux where system iocb structure layout changed recently after a system patch

### DIFF
--- a/sr_port/anticipatory_freeze.h
+++ b/sr_port/anticipatory_freeze.h
@@ -368,7 +368,7 @@ MBSTART {														\
 /* #GTM_THREAD_SAFE : The below macro (DB_LSEEKWRITEASYNCRESTART) is thread-safe */
 #define	DB_LSEEKWRITEASYNCRESTART(CSA, UDI, DB_FN, FD, BUFF, CR, STATUS)						\
 MBSTART {														\
-	DBG_CHECK_DIO_ALIGNMENT(UDI, CR->aiocb.sys_iocb.aio_offset, BUFF, CR->aiocb.sys_iocb.aio_nbytes);		\
+	DBG_CHECK_DIO_ALIGNMENT(UDI, SYS_IOCB(CR).aio_offset, BUFF, SYS_IOCB(CR).aio_nbytes);				\
 	DO_LSEEKWRITEASYNC(CSA, DB_FN, FD, 0, BUFF, 0, CR, STATUS, fake_db_enospc, LSEEKWRITE_IS_TO_DB_ASYNC_RESTART);	\
 } MBEND
 

--- a/sr_port/anticipatory_freeze.h
+++ b/sr_port/anticipatory_freeze.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2012-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -365,7 +368,7 @@ MBSTART {														\
 /* #GTM_THREAD_SAFE : The below macro (DB_LSEEKWRITEASYNCRESTART) is thread-safe */
 #define	DB_LSEEKWRITEASYNCRESTART(CSA, UDI, DB_FN, FD, BUFF, CR, STATUS)						\
 MBSTART {														\
-	DBG_CHECK_DIO_ALIGNMENT(UDI, CR->aiocb.aio_offset, BUFF, CR->aiocb.aio_nbytes);					\
+	DBG_CHECK_DIO_ALIGNMENT(UDI, CR->aiocb.sys_iocb.aio_offset, BUFF, CR->aiocb.sys_iocb.aio_nbytes);		\
 	DO_LSEEKWRITEASYNC(CSA, DB_FN, FD, 0, BUFF, 0, CR, STATUS, fake_db_enospc, LSEEKWRITE_IS_TO_DB_ASYNC_RESTART);	\
 } MBEND
 

--- a/sr_port/gdsfhead.h
+++ b/sr_port/gdsfhead.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -64,6 +64,12 @@ error_def(ERR_UNIMPLOP);
 
 #define FULL_FILESYSTEM_WRITE 1
 #define FULL_DATABASE_WRITE 2
+
+#ifdef USE_LIBAIO
+#	define	SYS_IOCB(CR)	CR->aiocb.sys_iocb
+#else
+#	define	SYS_IOCB(CR)	CR->aiocb
+#endif
 
 /* Cache record */
 typedef struct cache_rec_struct

--- a/sr_port/gtm_libaio.h
+++ b/sr_port/gtm_libaio.h
@@ -19,74 +19,70 @@
  * for non-technical reasons.
  */
 #if defined(__linux__) && defined(__x86_64__)
-#define USE_LIBAIO
+#	define USE_LIBAIO
 #elif defined(__CYGWIN__)
-#define USE_NOAIO
+#	define USE_NOAIO
 #endif
 
 #ifdef USE_NOAIO
-      /* AIO NOT SUPPORTED */
-/* minimal just to satisfy mur_init.c and mur_read_file.h.
- * More would be needed if MUR_USE_AIO were defined */
-struct aiocb {
-	int		aio_fildes;
-	volatile void	*aio_buf;
-	size_t		aio_nbytes;
-	off_t		aio_offset;
-	size_t		aio_bytesread;
-	int		aio_errno;
-};
-#define IF_LIBAIO(x) /* NONE */
-#define IF_LIBAIO_ELSE(x, y) y
+	/* AIO NOT SUPPORTED */
+	/* minimal just to satisfy mur_init.c and mur_read_file.h.
+	 * More would be needed if MUR_USE_AIO were defined */
+	struct aiocb {
+		int		aio_fildes;
+		volatile void	*aio_buf;
+		size_t		aio_nbytes;
+		off_t		aio_offset;
+		size_t		aio_bytesread;
+		int		aio_errno;
+	};
+#	define IF_LIBAIO(x) /* NONE */
+#	define IF_LIBAIO_ELSE(x, y) y
+
 #elif !defined(USE_LIBAIO)
-#include <aio.h>
-#define IF_LIBAIO(x) /* NONE */
-#define IF_LIBAIO_ELSE(x, y) y
+#	include <aio.h>
+#	define IF_LIBAIO(x) /* NONE */
+#	define IF_LIBAIO_ELSE(x, y) y
+
 #else	/* USE_LIBAIO */
-
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-#include <sys/syscall.h>
-#include <errno.h>
-#include <unistd.h>
-#include <string.h>
-#include <fcntl.h>
-#include <linux/aio_abi.h>
-
-#define	GTM_AIO_NR_EVENTS_DEFAULT 	128	/* Represents the default queue size for in-flight IO's
-						 * used by the kernel.
-						 */
-
-#define IO_SETUP_ERRSTR_ARRAYSIZE (MAX_TRANS_NAME_LEN + 11)
+#	ifndef _GNU_SOURCE
+#	define _GNU_SOURCE
+#	endif
+#	include <sys/syscall.h>
+#	include <errno.h>
+#	include <unistd.h>
+#	include <string.h>
+#	include <fcntl.h>
+#	include <linux/aio_abi.h>
+#	define	GTM_AIO_NR_EVENTS_DEFAULT 	128	/* Represents the default queue size for in-flight IO's
+							 * used by the kernel.
+							 */
+#	define IO_SETUP_ERRSTR_ARRAYSIZE (MAX_TRANS_NAME_LEN + 11)
 	/* We add 12 to the MAX_TRANS_NAME_LEN to make space for the
 	 * message, "io_setup(%d)\x00", where "%d" represents a
 	 * number that was parsed by trans_numeric(), hence the
 	 * MAX_TRANS_NAME_LEN usage.
 	 */
-#define IO_SETUP_FMT "io_setup(%d)"
-
-/* This struct mimics the structure of struct iocb, but adds a few fields
- * to the end for our own use. See <linux/aio_abi.h>::struct iocb.
- */
-struct aiocb {
-	struct iocb sys_iocb;	/* kernel internal structure */
-	/* YottaDB-specific extensions */
-	volatile int res;	/* If status is not EINPROGRESS, then denotes the
-				 * return value of the IO that just finished. The
-				 * return value is analagous to that of the return
-				 * value for a synchronous read()/write() syscall.
-				 */
-	volatile int status;	/* status of the IO in flight */
-};
-
-#define IF_LIBAIO(x) x
-#define IF_LIBAIO_ELSE(x,y) x
-
-/* linux/aio_abi.h provides PADDED to define the above struct, but this collides with
- * our personal #define which means something completely different.
- */
-#undef PADDED
+#	define IO_SETUP_FMT "io_setup(%d)"
+	/* This struct mimics the structure of struct iocb, but adds a few fields
+	 * to the end for our own use. See <linux/aio_abi.h>::struct iocb.
+	 */
+	struct aiocb {
+		struct iocb sys_iocb;	/* kernel internal structure */
+		/* YottaDB-specific extensions */
+		volatile int res;	/* If status is not EINPROGRESS, then denotes the
+					 * return value of the IO that just finished. The
+					 * return value is analagous to that of the return
+					 * value for a synchronous read()/write() syscall.
+					 */
+		volatile int status;	/* status of the IO in flight */
+	};
+#	define IF_LIBAIO(x) x
+#	define IF_LIBAIO_ELSE(x,y) x
+	/* linux/aio_abi.h provides PADDED to define the above struct, but this collides with
+	 * our personal #define which means something completely different.
+	 */
+#	undef PADDED
 #endif	/* USE_LIBAIO */
 
 #endif	/* GTM_LIBAIO_H_INCLUDED  */

--- a/sr_port/gtm_libaio.h
+++ b/sr_port/gtm_libaio.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2016-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -67,20 +70,8 @@ struct aiocb {
  * to the end for our own use. See <linux/aio_abi.h>::struct iocb.
  */
 struct aiocb {
-	/* kernel-internel structure, mirrors struct iocb */
-	__u64	aio_data;
-	__u32	PADDED(aio_key, aio_reserved1);
-	__u16	aio_lio_opcode;
-	__s16	aio_reqprio;
-	__u32	aio_fildes;
-	__u64	aio_buf;
-	__u64	aio_nbytes;
-	__s64	aio_offset;
-	__u64	aio_reserved2;
-	__u32	aio_flags;
-	__u32	aio_resfd;
-
-	/* personal implementation-specific definitions */
+	struct iocb sys_iocb;	/* kernel internal structure */
+	/* YottaDB-specific extensions */
 	volatile int res;	/* If status is not EINPROGRESS, then denotes the
 				 * return value of the IO that just finished. The
 				 * return value is analagous to that of the return

--- a/sr_unix/aio_shim.c
+++ b/sr_unix/aio_shim.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2016-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -89,24 +92,6 @@ enum
 	EXIT_EFD,
 	LAIO_EFD
 };
-
-/* checks that aiocb and iocb are equivalent */
-#define CHECK_OFFSETOF_FLD(x) ((offsetof(struct aiocb, x) == offsetof(struct iocb, x))			\
-				&& (SIZEOF(((struct aiocb *)0)->x) == SIZEOF(((struct iocb *)0)->x)))
-#define CHECK_STRUCT_AIOCB					\
-MBSTART {							\
-	assert(CHECK_OFFSETOF_FLD(aio_data) &&			\
-	       CHECK_OFFSETOF_FLD(aio_key) &&			\
-	       CHECK_OFFSETOF_FLD(aio_lio_opcode) &&		\
-	       CHECK_OFFSETOF_FLD(aio_reqprio) &&		\
-	       CHECK_OFFSETOF_FLD(aio_fildes) &&		\
-	       CHECK_OFFSETOF_FLD(aio_buf) &&			\
-	       CHECK_OFFSETOF_FLD(aio_nbytes) &&		\
-	       CHECK_OFFSETOF_FLD(aio_offset) &&		\
-	       CHECK_OFFSETOF_FLD(aio_reserved2) &&		\
-	       CHECK_OFFSETOF_FLD(aio_flags) &&			\
-	       CHECK_OFFSETOF_FLD(aio_resfd));			\
-} MBEND
 
 #define CLEANUP_AIO_SHIM_THREAD_INIT(GDI)				\
 MBSTART {								\
@@ -297,7 +282,7 @@ STATICFNDCL void clean_wip_queue(unix_db_info *udi)
 			     (cstt != (cache_state_rec_ptr_t)que_head);
 			      cstt = (cache_state_rec_ptr_t)((sm_uc_ptr_t)cstt + cstt->state_que.fl))
 			{
-				if ((cstt->epid == process_id) && ((aiocbp = &cstt->aiocb)->aio_fildes == udi->fd))
+				if ((cstt->epid == process_id) && ((aiocbp = &cstt->aiocb)->sys_iocb.aio_fildes == udi->fd))
 				{
 					AIO_SHIM_ERROR(aiocbp, ret);
 					if (EINPROGRESS == ret)
@@ -378,7 +363,6 @@ STATICFNDCL int aio_shim_thread_init(gd_addr *gd)
 	struct gd_info	*gdi, tmp_gdi;
 	sigset_t	savemask;
 
-	CHECK_STRUCT_AIOCB;
 	DEBUG_ONLY(aio_shim_errstr = NULL;)
 	/* initialize fields of tmp_gdi */
 	tmp_gdi.exit_efd = FD_INVALID;

--- a/sr_unix/gtmio.h
+++ b/sr_unix/gtmio.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -373,8 +376,8 @@ MBSTART {											\
 #define LSEEKWRITEASYNCSTART(CSA, FDESC, FPTR, FBUFF, FBUFF_LEN, CR, RC)			\
 MBSTART {											\
 	memset(&CR->aiocb, 0, SIZEOF(struct aiocb));						\
-	CR->aiocb.aio_nbytes = (size_t) FBUFF_LEN;						\
-	CR->aiocb.aio_offset = (off_t) FPTR;							\
+	CR->aiocb.sys_iocb.aio_nbytes = (size_t) FBUFF_LEN;					\
+	CR->aiocb.sys_iocb.aio_offset = (off_t) FPTR;						\
 	LSEEKWRITEASYNCRESTART(CSA, FDESC, FBUFF, CR, RC);					\
 } MBEND
 
@@ -383,10 +386,10 @@ MBSTART {											\
 	GBLREF 	boolean_t	async_restart_got_eagain;					\
 	ssize_t			gtmioStatus;							\
 												\
-	CR->aiocb.aio_buf = IF_LIBAIO((unsigned long)) FBUFF;					\
-	CR->aiocb.aio_fildes = FDESC;								\
-	assert(0 < CR->aiocb.aio_nbytes);							\
-	assert(0 < CR->aiocb.aio_offset);							\
+	CR->aiocb.sys_iocb.aio_buf = IF_LIBAIO((unsigned long)) FBUFF;					\
+	CR->aiocb.sys_iocb.aio_fildes = FDESC;								\
+	assert(0 < CR->aiocb.sys_iocb.aio_nbytes);							\
+	assert(0 < CR->aiocb.sys_iocb.aio_offset);							\
 	AIO_SHIM_WRITE(CSA->region, &(CR->aiocb), gtmioStatus);					\
 	if (0 == gtmioStatus)									\
 		RC = 0;										\

--- a/sr_unix/gtmio.h
+++ b/sr_unix/gtmio.h
@@ -373,12 +373,12 @@ MBSTART {											\
 		RC = -1;		/* Something kept us from reading what we wanted */	\
 } MBEND
 
-#define LSEEKWRITEASYNCSTART(CSA, FDESC, FPTR, FBUFF, FBUFF_LEN, CR, RC)			\
-MBSTART {											\
-	memset(&CR->aiocb, 0, SIZEOF(struct aiocb));						\
-	CR->aiocb.sys_iocb.aio_nbytes = (size_t) FBUFF_LEN;					\
-	CR->aiocb.sys_iocb.aio_offset = (off_t) FPTR;						\
-	LSEEKWRITEASYNCRESTART(CSA, FDESC, FBUFF, CR, RC);					\
+#define LSEEKWRITEASYNCSTART(CSA, FDESC, FPTR, FBUFF, FBUFF_LEN, CR, RC)	\
+MBSTART {									\
+	memset(&CR->aiocb, 0, SIZEOF(struct aiocb));				\
+	SYS_IOCB(CR).aio_nbytes = (size_t) FBUFF_LEN;				\
+	SYS_IOCB(CR).aio_offset = (off_t) FPTR;					\
+	LSEEKWRITEASYNCRESTART(CSA, FDESC, FBUFF, CR, RC);			\
 } MBEND
 
 #define LSEEKWRITEASYNCRESTART(CSA, FDESC, FBUFF, CR, RC)					\
@@ -386,10 +386,10 @@ MBSTART {											\
 	GBLREF 	boolean_t	async_restart_got_eagain;					\
 	ssize_t			gtmioStatus;							\
 												\
-	CR->aiocb.sys_iocb.aio_buf = IF_LIBAIO((unsigned long)) FBUFF;					\
-	CR->aiocb.sys_iocb.aio_fildes = FDESC;								\
-	assert(0 < CR->aiocb.sys_iocb.aio_nbytes);							\
-	assert(0 < CR->aiocb.sys_iocb.aio_offset);							\
+	SYS_IOCB(CR).aio_buf = IF_LIBAIO((unsigned long)) FBUFF;				\
+	SYS_IOCB(CR).aio_fildes = FDESC;							\
+	assert(0 < SYS_IOCB(CR).aio_nbytes);							\
+	assert(0 < SYS_IOCB(CR).aio_offset);							\
 	AIO_SHIM_WRITE(CSA->region, &(CR->aiocb), gtmioStatus);					\
 	if (0 == gtmioStatus)									\
 		RC = 0;										\

--- a/sr_unix/wcs_wt_restart.c
+++ b/sr_unix/wcs_wt_restart.c
@@ -66,7 +66,7 @@ int	wcs_wt_restart(unix_db_info *udi, cache_state_rec_ptr_t csr)
 			 * Do synchronous IO given OS does not have enough memory temporarily.
 			 */
 			DB_LSEEKWRITE(csa, udi, udi->fn, udi->fd,
-				csr->aiocb.sys_iocb.aio_offset, save_bp, csr->aiocb.sys_iocb.aio_nbytes, save_errno);
+				SYS_IOCB(csr).aio_offset, save_bp, SYS_IOCB(csr).aio_nbytes, save_errno);
 			assert(0 <= save_errno);
 			if (0 == save_errno)
 			{	/* SYNCIO succeeded. Return special status */

--- a/sr_unix/wcs_wt_restart.c
+++ b/sr_unix/wcs_wt_restart.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2016 Fidelity National Information		*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -63,7 +66,7 @@ int	wcs_wt_restart(unix_db_info *udi, cache_state_rec_ptr_t csr)
 			 * Do synchronous IO given OS does not have enough memory temporarily.
 			 */
 			DB_LSEEKWRITE(csa, udi, udi->fn, udi->fd,
-				csr->aiocb.aio_offset, save_bp, csr->aiocb.aio_nbytes, save_errno);
+				csr->aiocb.sys_iocb.aio_offset, save_bp, csr->aiocb.sys_iocb.aio_nbytes, save_errno);
 			assert(0 <= save_errno);
 			if (0 == save_errno)
 			{	/* SYNCIO succeeded. Return special status */


### PR DESCRIPTION
The system header file involved is /usr/include/linux/aio_abi.h and the structure involved is struct iocb.
This header file is found in the
	linux-libc-dev package on Ubuntu/Debian
	linux-api-headers package on Arch
	kernel-headers package on RHEL/CentOS
The version of linux-api-headers package afer the system patch was 4.14.8-1.
This had a different layout than the one which was copied over to the YottaDB codebase.
And that caused compile time errors. To avoid this issue (and future issues with structure layout changes),
	the change done was to keep the system "struct iocb" structure as a member of the aiocb structure
	defined in the YottaDB codebase. Because of this change, some usages of members in the system iocb
	structure had to be changed to have an extra structure member dereference.
But this meant no structure layout assumptions like before.
With these changes, the build on Arch linux passed fine (and the other platforms continued to build fine).