### PR TITLE
[#141] Fix ZSTEP OVER and ZSTEP OUTOF to work if an extrinsic function returns using QUIT @ syntax

### DIFF
--- a/sr_armv7l/op_bkpt.s
+++ b/sr_armv7l/op_bkpt.s
@@ -1,6 +1,6 @@
 #################################################################
 #								#
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 # Copyright (c) 2017 Stephen L Johnson. All rights reserved.	#
@@ -56,10 +56,8 @@ l1:
 ENTRY opp_zstepretarg
 	push	{r0, r1}
 	CHKSTKALIGN				/* Verify stack alignment */
+	bl	op_zstepretarg_helper
 	ldr	r12, [r5]
-	ldrh	r0, [r12, +#msf_typ_off]
-	tst	r0, #1
-	beq	l2
 	ldr	r1, =zstep_level
 	ldr	r1, [r1]
 	cmp	r1, r12
@@ -279,13 +277,11 @@ l11:
 ENTRY opp_zst_over_retarg
 	push	{r0, r1}
 	CHKSTKALIGN				/* Verify stack alignment */
+	bl	op_zst_over_retarg_helper
 	ldr	r12, [r5]
-	ldrh	r1, [r12, #msf_typ_off]
-	tst	r1, #1
-	beq	l12
+	ldr	r0, [r12, #msf_old_frame_off]
 	ldr	r1, =zstep_level
 	ldr	r1, [r1]
-	ldr	r0, [r12, #msf_old_frame_off]
 	cmp	r1, r0
 	bgt	l12
 	bl	op_zstepret

--- a/sr_port/op.h
+++ b/sr_port/op.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -308,4 +308,6 @@ int	opp_zstepret();
 int	opp_zstepretarg();
 void	op_zut(mval *s);
 void	op_zwritesvn(int svn);
+void	op_zst_over_retarg_helper(void);
+void	op_zstepretarg_helper(void);
 #endif

--- a/sr_port/op_zst_over_retarg_helper.c
+++ b/sr_port/op_zst_over_retarg_helper.c
@@ -1,0 +1,41 @@
+/****************************************************************
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
+
+#include "mdef.h"
+
+#include <rtnhdr.h>
+#include "stack_frame.h"
+#include "op.h"
+
+GBLREF unsigned char	*zstep_level;
+GBLREF stack_frame	*frame_pointer;
+
+/* This function is written in C since it is easier than writing this in assembly for multiple platforms.
+ * The main purpose is to ensure that ZSTEP OVER works correctly in a QUIT @x situation.
+ * In this case, a nested uncounted frame is created for the @ usage and a OC_RETARG is done from the nested frame
+ * and it also returns from the parent counted frame so if a ZSTEP OVER was in effect in the parent frame, the
+ * QUIT from the nested uncounted frame should be treated as if it is a QUIT from the parent frame for ZSTEP OVER purposes.
+ * We achieve this by modifying the global "zstep_level" to the uncounted frame (that is the check done by
+ * "op_zst_over_retarg" (in op_bkpt.s) to decide whether "op_zstepret" or "op_retarg" needs to be invoked.
+ */
+void	op_zst_over_retarg_helper(void)
+{
+	stack_frame	*fp;
+
+	for (fp = frame_pointer; fp ; fp = fp->old_frame_pointer)
+	{
+		if (fp->type & SFT_COUNT)
+			break;
+	}
+	if ((NULL != fp) && ((unsigned char *)fp->old_frame_pointer == zstep_level))
+		zstep_level = (unsigned char *)frame_pointer->old_frame_pointer;
+}

--- a/sr_port/op_zstep.c
+++ b/sr_port/op_zstep.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -55,12 +58,10 @@ void op_zstep(uint4 code, mval *action)
 			break;
 		case ZSTEP_OVER:
 		case ZSTEP_OUTOF:
-
-			fp = frame_pointer;
 			for (fp = frame_pointer; fp ; fp = fp->old_frame_pointer)
-			{	if (fp->type & SFT_COUNT)
-				{	break;
-				}
+			{
+				if (fp->type & SFT_COUNT)
+					break;
 			}
 			zstep_level = (unsigned char *) fp;
 			if (!neterr_pending && 0 == outofband && 0 == iott_write_error)

--- a/sr_port/op_zstepretarg_helper.c
+++ b/sr_port/op_zstepretarg_helper.c
@@ -1,0 +1,41 @@
+/****************************************************************
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
+
+#include "mdef.h"
+
+#include <rtnhdr.h>
+#include "stack_frame.h"
+#include "op.h"
+
+GBLREF unsigned char	*zstep_level;
+GBLREF stack_frame	*frame_pointer;
+
+/* This function is written in C since it is easier than writing this in assembly for multiple platforms.
+ * The main purpose is to ensure that ZSTEP OUTOF works correctly in a QUIT @x situation.
+ * In this case, a nested uncounted frame is created for the @ usage and a OC_RETARG is done from the nested frame
+ * and it also returns from the parent counted frame so if a ZSTEP OUTOF was in effect in the parent frame, the
+ * QUIT from the nested uncounted frame should be treated as if it is a QUIT from the parent frame for ZSTEP OUTOF purposes.
+ * We achieve this by modifying the global "zstep_level" to the uncounted frame (that is the check done by
+ * "op_zstepretarg" (in op_bkpt.s) to decide whether "op_zstepret" or "op_retarg" needs to be invoked.
+ */
+void	op_zstepretarg_helper(void)
+{
+	stack_frame	*fp;
+
+	for (fp = frame_pointer; fp ; fp = fp->old_frame_pointer)
+	{
+		if (fp->type & SFT_COUNT)
+			break;
+	}
+	if ((NULL != fp) && ((unsigned char *)fp == zstep_level))
+		zstep_level = (unsigned char *)frame_pointer;
+}

--- a/sr_x86_64/op_bkpt.s
+++ b/sr_x86_64/op_bkpt.s
@@ -3,7 +3,7 @@
 # Copyright (c) 2007-2015 Fidelity National Information 	#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
-# Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	#
+# Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.	#
 # All rights reserved.						#
 #								#
 #	This source code contains the intellectual property	#
@@ -53,10 +53,8 @@ ENTRY	opp_zstepretarg
 	CHKSTKALIGN					# Verify stack alignment
 	movq	REG64_RET0, save0(REG_SP)		# Save input regs
 	movq	REG64_RET1, save1(REG_SP)
+	call	op_zstepretarg_helper
 	movq	frame_pointer(REG_IP), REG64_ACCUM
-	movw	msf_typ_off(REG64_ACCUM), REG16_ARG2
-	testw	$1, REG16_ARG2
-	je	l2
 	movq	zstep_level(REG_IP), REG64_ARG2
 	cmpq	REG64_ACCUM, REG64_ARG2
 	jg	l2
@@ -230,12 +228,10 @@ ENTRY	opp_zst_over_retarg
 	CHKSTKALIGN					# Verify stack alignment
 	movq	REG64_RET0, save0(REG_SP)		# Save input regs
 	movq	REG64_RET1, save1(REG_SP)
+	call	op_zst_over_retarg_helper
 	movq	frame_pointer(REG_IP), REG64_ACCUM
-	movw	msf_typ_off(REG64_ACCUM), REG16_ARG2
-	testw	$1, REG16_ARG2
-	je	l12
-	movq	zstep_level(REG_IP), REG64_ARG2
 	movq	msf_old_frame_off(REG64_ACCUM), REG64_ACCUM
+	movq	zstep_level(REG_IP), REG64_ARG2
 	cmpq	REG64_ACCUM, REG64_ARG2
 	jg	l12
 	call	op_zstepret


### PR DESCRIPTION
ZSTEP OVER operates (in op_zstep.c) by noting down the current $zlevel in the global variable
"zstep_level" and changing the transfer table so "opp_zst_over_retarg" is invoked instead of
"op_retarg" but otherwise leaves the transfer table untouched so op_linestart etc. are still
executed as normal as long as nested levels of M frames are invoked. If the nested level
invocation is an extrinsic function (that returns a value) "opp_zst_over_retarg" is invoked as
part of returning from that level. "opp_zst_over_retarg" (in op_bkpt.s) checks if "zstep_level"
is the same as frame_pointer->old_frame_pointer and if so, it calls "op_zstepret" to fix the
transfer table so "op_zst_st_over" is invoked instead of "op_linestart" (and so on). That is,
the ZSTEP action which was hidden during nested levels of invocations becomes active the moment
the return from nested level occurs. This check did not take into account that in case of a
QUIT @ usage, due to the indirection usage, there is an extra nested uncounted frame that is
where the OC_RETARG opcode happens. So "opp_zst_over_retarg" gets invoked while the global
variable "frame_pointer" is 2 levels deeper than "zstep_level" but one of those 2 levels
is an uncounted frame. In this case the "frame_pointer->old_frame_pointer == zstep_level"
check in "opp_zst_over_retarg" incorrectly decided it was not yet time to make the ZSTEP
action active. This is now fixed by invoking a C helper function "op_zst_over_retarg_helper"
which takes these uncounted frames into account and ensures (by adjusting "zstep_level") that
"opp_zst_over_retarg" does the right thing even in this case.

A similar issue with ZSTEP OUTOF which now has "op_zstepretarg_helper" ensuring "opp_zstepretarg"
does the right thing.

Since assembly modules are involved, the fix is needed separately for the x86_64 and armv7l
architectures. But the more complicated part of the fix (traversing the frame_pointer linked
list and checking for counted frames) was done in C helper functions to minimize assembly changes.