### PR TITLE
[#97] ydb_msgprefix env var controls YottaDB message prefix for merrors.msg errors (default is "YDB")

### DIFF
--- a/sr_port/gtm_threadgbl_defs.h
+++ b/sr_port/gtm_threadgbl_defs.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2010-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -492,6 +492,11 @@ THREADGBLDEF(last_gvquery_key,			gv_key *)	/* Last key returned by $query(gvn). 
 								 * maintained for both forward and reverse $query(gvn)
 								 * This is the gv equivalent of last_fnquery_return_varname et al.
 								 */
+THREADGBLAR1DEF(ydbmsgprefixbuf,		char,	32)	/* The message prefix buffer size is chosen to allow at least
+								 * 8 4-byte unicode characters or 32 ascii characters.
+								 */
+THREADGBLDEF(ydbmsgprefix,			mstr)		/* mstr pointing to msgprefixbuf containing the YDB prompt */
+
 /* Debug values */
 #ifdef DEBUG
 THREADGBLDEF(LengthReentCnt,			boolean_t)	/* Reentrancy count for GetPieceCountFromPieceCache() used by 2

--- a/sr_port/gtm_threadgbl_init.c
+++ b/sr_port/gtm_threadgbl_init.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2010-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -146,7 +146,12 @@
 
 #include "gtm_threadgbl_init.h"
 
-#define	DEFAULT_PROMPT	"YDB>"
+#define	DEFAULT_PROMPT		"YDB>"
+#define	DEFAULT_MSGPREFIX	"YDB"
+
+#ifdef DEBUG
+# define SIZEOF_ydbmsgprefixbuf	ggl_ydbmsgprefixbuf
+#endif
 
 GBLDEF void	*gtm_threadgbl;		/* Anchor for thread global for this thread */
 
@@ -210,10 +215,10 @@ void gtm_threadgbl_init(void)
 	TREF(for_stack_ptr) = TADR(for_stack);
 	(TREF(gtmprompt)).addr = TADR(prombuf);
 	(TREF(gtmprompt)).len = SIZEOF(DEFAULT_PROMPT) - 1;
+	MEMCPY_LIT(TADR(prombuf), DEFAULT_PROMPT);
 	TREF(lv_null_subs) = LVNULLSUBS_OK;	/* UNIX: set in gtm_env_init_sp(), VMS: set in gtm$startup() - init'd here
 							 * in case alternative invocation methods bypass gtm_startup()
 							 */
-	MEMCPY_LIT(TADR(prombuf), DEFAULT_PROMPT);
 	(TREF(replgbl)).jnl_release_timeout = DEFAULT_JNL_RELEASE_TIMEOUT;
 	(TREF(window_ident)).addr = TADR(window_string);
 	ASSERT_SAFE_TO_UPDATE_THREAD_GBLS;
@@ -221,4 +226,9 @@ void gtm_threadgbl_init(void)
 	TREF(util_outptr) = TREF(util_outbuff_ptr);
 	(TREF(source_buffer)).addr = (char *)&aligned_source_buffer;
 	(TREF(source_buffer)).len = MAX_SRCLINE;
+	assert(SIZEOF_ydbmsgprefixbuf >= SIZEOF(DEFAULT_MSGPREFIX));
+	(TREF(ydbmsgprefix)).addr = TADR(ydbmsgprefixbuf);
+	(TREF(ydbmsgprefix)).len = STR_LIT_LEN(DEFAULT_MSGPREFIX);	/* STR_LIT_LEN does not include terminating null byte */
+	MEMCPY_LIT(TADR(ydbmsgprefixbuf), DEFAULT_MSGPREFIX);
+	(TREF(ydbmsgprefix)).addr[(TREF(ydbmsgprefix)).len] = '\0';	/* need null terminated "fac" in "gtm_getmsg" */
 }

--- a/sr_port/merrors_ctl.c
+++ b/sr_port/merrors_ctl.c
@@ -1513,6 +1513,6 @@ LITDEF	err_msg merrors[] = {
 
 GBLDEF	err_ctl merrors_ctl = {
 	246,
-	"GTM",
+	"YDB",
 	&merrors[0],
 	1491};

--- a/sr_unix/gtm_logicals.h
+++ b/sr_unix/gtm_logicals.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -159,4 +159,5 @@
 
 /* YottaDB specified variables */
 #define	YDB_REPL_FILTER_TIMEOUT		"$ydb_repl_filter_timeout"
+#define	YDB_MSGPREFIX			"$ydb_msgprefix"
 


### PR DESCRIPTION
If the env var is unset, the default prefix is "YDB"

If the env var is set to a string that is less than or equal to 31 bytes long, the env var
value is taken as the message prefix.

If the env var is set to a string that is more than 31 bytes long, the default prefix of "YDB"
is assumed.

Note the this env var only affects error messages in merrors.msg and not other the errors in
other .msg files (e.g. ydberrors.msg, gdeerrors.msg etc.)

Also the ydb_msgprefix initialization is done at the top of gtm_env_init() (instead of the
usual practice which is to add it to the end of the file) to ensure user-specified msgprefix
is honored if/when issuing errors inside gtm_env_init().