### PR TITLE
[#145] Ensure MV_INT bit is set if result of multiply or divide of two non-integer numeric quantities is 0

### DIFF
--- a/sr_port/op_div.c
+++ b/sr_port/op_div.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2011 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2011 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -31,6 +34,7 @@ void	op_div (mval *u, mval *v, mval *q)
 
 	MV_FORCE_NUM(u);
 	MV_FORCE_NUM(v);
+	assert((v->mvtype & MV_INT) || (0 != v->m[0]) || (0 != v->m[1]));
 	if ((v->mvtype & MV_INT)  &&  v->m[1] == 0)
 		rts_error(VARLSTCNT(1) ERR_DIVZERO);
 	if (u->mvtype & MV_INT & v->mvtype)
@@ -65,6 +69,8 @@ void	op_div (mval *u, mval *v, mval *q)
 		*q = literal_zero;
 	else if (exp < EXP_INT_OVERF  &&  exp > EXP_INT_UNDERF  &&  q->m[0] == 0  &&  (q->m[1]%ten_pwr[EXP_INT_OVERF-1-exp] == 0))
 		demote(q, exp, u->sgn ^ v->sgn);
+	else if ((0 == q->m[0]) && (0 == q->m[1]))
+		*q = literal_zero;
 	else
 	{
 		q->mvtype = MV_NM;

--- a/sr_port/op_idiv.c
+++ b/sr_port/op_idiv.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2011 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2011 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -31,6 +34,7 @@ void	op_idiv(mval *u, mval *v, mval *q)
 
 	MV_FORCE_NUM(u);
 	MV_FORCE_NUM(v);
+	assert((v->mvtype & MV_INT) || (0 != v->m[0]) || (0 != v->m[1]));
 	if ((v->mvtype & MV_INT)  &&  v->m[1] == 0)
 		rts_error(VARLSTCNT(1) ERR_DIVZERO);
 	if (u->mvtype & MV_INT & v->mvtype)

--- a/sr_port/op_mul.c
+++ b/sr_port/op_mul.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2011 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2011 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -24,7 +27,6 @@ void	op_mul (mval *u, mval *v, mval *p)
 	bool		promo;
 	int4		c, exp;
 	mval		w, z;
-	error_def	(ERR_NUMOFLOW);
 
 	MV_FORCE_NUM(u);
 	MV_FORCE_NUM(v);
@@ -35,21 +37,18 @@ void	op_mul (mval *u, mval *v, mval *p)
 		{
 			p->mvtype = MV_NM | MV_INT;
 			return;
-		}
-		else
+		} else
 		{
 			w = *u;      z = *v;
 			promote(&w); promote(&z);
 			u = &w;	     v = &z;
 		}
-	}
-	else if (u->mvtype & MV_INT)
+	} else if (u->mvtype & MV_INT)
 	{
 		w = *u;
 		promote(&w);
 		u = &w;
-	}
-	else if (v->mvtype & MV_INT)
+	} else if (v->mvtype & MV_INT)
 	{
 		w = *v;
 		promote(&w);
@@ -63,6 +62,8 @@ void	op_mul (mval *u, mval *v, mval *p)
 		*p = literal_zero;
 	else if (exp < EXP_INT_OVERF  &&  exp > EXP_INT_UNDERF  &&  p->m[0] == 0  &&  (p->m[1]%ten_pwr[EXP_INT_OVERF-1-exp]==0))
 		demote(p, exp, u->sgn ^ v->sgn);
+	else if ((0 == p->m[0]) && (0 == p->m[1]))
+		*p = literal_zero;
 	else
 	{
 		p->mvtype = MV_NM;


### PR DESCRIPTION
Not doing so could cause a later use of this result mval in a division operation to issue a
fatal SIGINTDIV error (instead of a user-trappable DIVZERO error). This is because op_div.c
and op_idiv.c assume that if the divisor has the MV_INT bit not set, it is a non-zero value.

The MV_INT bit set is achieved by checking explicitly if both the mantissa (m[0] and m[1])
are zero and if so setting the mval to "literal_zero".