### PR TITLE
[#94] Fix usage of march=armv6 in sr_linux/gtm_env_sp.csh (used by test system) to be in sync with that in sr_linux/platform.cmake (used by cmake build)

### DIFF
--- a/sr_linux/gtm_env_sp.csh
+++ b/sr_linux/gtm_env_sp.csh
@@ -111,7 +111,7 @@ if ( $?gtm_version_change == "1" ) then
 	        setenv gt_as_options_common	"--defsym cygwin=1"
 	    	setenv gt_as_option_debug	"--gdwarf-2"
 	    else if ("armv6l" == $mach_type) then
-	        setenv gt_as_options_common	"-Wa,-march=armv6zk"
+	        setenv gt_as_options_common	"-Wa,-march=armv6"
 		setenv gt_as_option_debug	"--gdwarf-2"
 	    else if ("armv7l" == $mach_type) then
 	        setenv gt_as_options_common	"-Wa,-march=armv7-a"
@@ -154,7 +154,7 @@ if ( $?gtm_version_change == "1" ) then
 	if ( "armv6l" == $mach_type ) then
 		setenv	gt_ld_m_shl_linker	"cc"
 		setenv  gt_ld_m_shl_options     "-shared"
-		setenv  gt_cc_options_common    "$gt_cc_options_common -marm -march=armv6zk "
+		setenv  gt_cc_options_common    "$gt_cc_options_common -marm -march=armv6 "
 	endif
 	if ( "armv7l" == $mach_type ) then
 		setenv	gt_ld_m_shl_linker	"cc"


### PR DESCRIPTION
The previous #94 commit added a "# error UNSUPPORTED PLATFORM" in sr_unix/mdefsp.h which
would kick in if the system is an ARMV6 and the __ARM_ARCH_6__ macro is not defined. This
macro is defined only in case -march=armv6 is specified (which is the case in the cmake
build). But the test system uses settings from sr_linux/gtm_env_sp.csh where -march=armv6zk
is defined which instead defines the macro __ARM_ARCH_6ZK__ and therefore reaches the
UNSUPPORTED PLATFORM codepath in mdefsp.h which compiling C programs during testing. The
fix is to keep the two in sync.