### PR TITLE
Change relative path to ydbmerrors to use src directory

### DIFF
--- a/sr_linux/platform.cmake
+++ b/sr_linux/platform.cmake
@@ -48,7 +48,7 @@ else()
   set(arch "x86_64")
   set(bits 64)
 endif()
-set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -include ../sr_port/ydbmerrors.h")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -include ${YDB_SOURCE_DIR}/sr_port/ydbmerrors.h")
 
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -x assembler-with-cpp")
 # Platform directories


### PR DESCRIPTION
Use the YDB_SOURCE_DIR cmake variable to get the path to ydbmerrors.h
instead of a hardcoded relative path