### PR TITLE
[#83] Enhance M READ Editing in terminal to have history of 99 lines (same as direct mode)

### DIFF
--- a/sr_unix/iott_open.c
+++ b/sr_unix/iott_open.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2016 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -183,14 +186,6 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, int4 time
 			tt_ptr->default_mask_term = TRUE;
 		}
 		ioptr->state = dev_open;
-		if ((TT_EDITING & tt_ptr->ext_cap) && !tt_ptr->recall_buff.addr)
-		{
-			assert(tt_ptr->in_buf_sz);
-			tt_ptr->recall_buff.addr = malloc(tt_ptr->in_buf_sz);
-			tt_ptr->recall_size = tt_ptr->in_buf_sz;
-			tt_ptr->recall_buff.len = 0;	/* nothing in buffer */
-			tt_ptr->recall_width = 0;
-		}
 	} else
 	{
 		/* Set terminal mask on the already open terminal, if CHSET changes */

--- a/sr_unix/iott_rdone.c
+++ b/sr_unix/iott_rdone.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -494,20 +497,12 @@ int	iott_rdone (mint *v, int4 msec_timeout)	/* timeout in milliseconds */
 		*v = INPUT_CHAR;
 		if ((TT_EDITING & tt_ptr->ext_cap) && !((TRM_PASTHRU|TRM_NOECHO) & mask))
 		{	/* keep above test in sync with iott_readfl */
-			assert(tt_ptr->recall_buff.addr);
 			if (!utf8_active)
-			{
-				tt_ptr->recall_buff.addr[0] = INPUT_CHAR;
-				tt_ptr->recall_buff.len = 1;
-			}
+				iott_recall_array_add(tt_ptr, 1, inchar_width, 1, &INPUT_CHAR);
 #			ifdef UNICODE_SUPPORTED
 			else
-			{
-				memcpy(tt_ptr->recall_buff.addr, &INPUT_CHAR, SIZEOF(INPUT_CHAR));
-				tt_ptr->recall_buff.len = SIZEOF(INPUT_CHAR);
-			}
+				iott_recall_array_add(tt_ptr, 1, inchar_width, SIZEOF(INPUT_CHAR), &INPUT_CHAR);
 #			endif
-			tt_ptr->recall_width = inchar_width;
 		}
 		/* SIMPLIFY THIS! */
 		if (!utf8_active || ASCII_MAX >= INPUT_CHAR)

--- a/sr_unix/iott_recall_array_add.c
+++ b/sr_unix/iott_recall_array_add.c
@@ -1,0 +1,57 @@
+/****************************************************************
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
+
+#include "mdef.h"
+
+#include "gtm_string.h"
+
+#include "gt_timer.h"
+#include "io.h"
+#include "iottdef.h"
+#include "comline.h"
+
+/* Add a line of input into "tt_ptr->recall_array" history */
+void	iott_recall_array_add(d_tt_struct *tt_ptr, int nchars, int width, int bytelen, void *ptr)
+{
+	int		recall_index, prev_recall_index;
+	recall_ctxt_t	*recall, *prev_recall;
+
+	assert(bytelen >= nchars);
+	if (!bytelen)
+		return;	/* no point adding NULL strings to history */
+	if (NULL == tt_ptr->recall_array)
+	{	/* Allocate "recall_array" first */
+		recall = malloc(MAX_RECALL * SIZEOF(recall_ctxt_t));
+		memset(recall, 0, MAX_RECALL * SIZEOF(recall_ctxt_t));
+		assert(0 == tt_ptr->recall_index);
+		tt_ptr->recall_array = recall;
+	}
+	recall_index = tt_ptr->recall_index;
+	assert(0 <= recall_index);
+	assert(MAX_RECALL > recall_index);
+	recall = &tt_ptr->recall_array[recall_index];
+	prev_recall_index = (0 == recall_index) ? (MAX_RECALL - 1) : (recall_index - 1);
+	prev_recall = &tt_ptr->recall_array[prev_recall_index];
+	if ((bytelen == prev_recall->bytelen) && !memcmp(ptr, prev_recall->buff, bytelen))
+		return;	/* No point adding duplicate history lines. Return */
+	if (NULL != recall->buff)
+		free(recall->buff);
+	recall->nchars = nchars;
+	recall->width = width;
+	recall->bytelen = bytelen;
+	recall->buff = malloc(bytelen);
+	memcpy(recall->buff, ptr, bytelen);
+	if (MAX_RECALL <= ++recall_index)
+		recall_index = 0;
+	tt_ptr->recall_index = recall_index;
+	return;
+}

--- a/sr_unix/iott_use.c
+++ b/sr_unix/iott_use.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -214,13 +217,6 @@ void iott_use(io_desc *iod, mval *pp)
 					if (io_curr_device.in == io_std_device.in)
 					{	/* $PRINCIPAL only */
 						tt_ptr->ext_cap |= TT_EDITING;
-						if (!tt_ptr->recall_buff.addr)
-						{
-							assert(tt_ptr->in_buf_sz);
-							tt_ptr->recall_buff.addr = malloc(tt_ptr->in_buf_sz);
-							tt_ptr->recall_size = tt_ptr->in_buf_sz;
-							tt_ptr->recall_buff.len = 0;    /* nothing in buffer */
-						}
 					}
 					break;
 				case iop_noediting:


### PR DESCRIPTION
M READ Editing is a pre-existing feature in YottaDB that is enabled with USE $PRINCIPAL:EDITING
But that maintained only a history of 1 recall item. That is, a cursor up in a READ X command
would recall the most recently entered input to a previous READ X, READ *X or READ X# command.
This change enhances that history from 1 line to 99 lines. Just like direct mode operates.

Relevant details
-----------------
* A circular buffer tt_ptr->recall_array is maintained for past terminal read inputs (99).
* The global tt_ptr->recall_index points to the current index into this array.
* READ X# (iott_readfl), READ *X (iott_rdone) and READ X (iott_read which in turn calls iott_readfl)
  commands all share the same history.
* Cursor UP goes back in history (from most recently added item back to oldest item)
* Cursor DOWN goes forward in history (from oldest item in history to newest item)
* Empty lines do not get added to history.
* Duplicate lines do not get added to history.