### PR TITLE
[#169] Restore condition handler stack on trigger frame unwind only if it is a forced unwind

### DIFF
--- a/sr_port/gtm_threadgbl_defs.h
+++ b/sr_port/gtm_threadgbl_defs.h
@@ -496,6 +496,7 @@ THREADGBLAR1DEF(ydbmsgprefixbuf,		char,	32)	/* The message prefix buffer size is
 								 * 8 4-byte unicode characters or 32 ascii characters.
 								 */
 THREADGBLDEF(ydbmsgprefix,			mstr)		/* mstr pointing to msgprefixbuf containing the YDB prompt */
+THREADGBLDEF(trig_forced_unwind,		boolean_t)	/* set/used by "gtm_trigger_fini", "op_unwind" and "unw_mv_ent" */
 
 /* Debug values */
 #ifdef DEBUG

--- a/sr_port/op_unwind.c
+++ b/sr_port/op_unwind.c
@@ -114,7 +114,11 @@ void op_unwind(void)
 		unw_mv_ent(mvc);
 		mvc = (mv_stent *)(mvc->mv_st_next + (char *)mvc);
 	}
-	TREF(trig_forced_unwind) = FALSE;	/* reset this global right away in case we hit an error codepath below */
+	TREF(trig_forced_unwind) = FALSE;	/* Again, turn this global flag off while it is not needed in case of error below.
+						 * Note that even though "unw_mv_ent" could clear this global in case it unwound
+						 * a MVST_TRGR mv_stent, we are not guaranteed an MVST_TRGR mv_stent is there on
+						 * the M-stack in all calls to "op_unwind" and hence clear this here too.
+						 */
 	if (0 <= frame_pointer->dollar_test)		/* get dollar_test if it has been set */
 		dollar_truth = frame_pointer->dollar_test;
 	if (is_tracing_on GTMTRIG_ONLY( && !(frame_pointer->type & SFT_TRIGR)))

--- a/sr_port/op_unwind.c
+++ b/sr_port/op_unwind.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -66,10 +66,13 @@ void op_unwind(void)
 {
 	rhdtyp			*rtnhdr;
 	mv_stent 		*mvc;
+	boolean_t		trig_forced_unwind;
 	DBGEHND_ONLY(stack_frame *prevfp;)
 	DCL_THREADGBL_ACCESS;
 
 	SETUP_THREADGBL_ACCESS;
+	trig_forced_unwind = TREF(trig_forced_unwind); 	/* save a copy of global into local */
+	TREF(trig_forced_unwind) = FALSE;	/* reset this global right away in case we hit an error codepath below */
 	assert((frame_pointer < frame_pointer->old_frame_pointer) || (NULL == frame_pointer->old_frame_pointer));
 	if (frame_pointer->type & SFT_COUNT)
 	{	/* If unwinding a counted frame, make sure we clean up any alias return argument in flight */
@@ -102,11 +105,16 @@ void op_unwind(void)
 	assert(frame_pointer <= (stack_frame*)stackbase && frame_pointer > (stack_frame *)stacktop);
 	/* See if unwinding an indirect frame */
 	IF_INDR_FRAME_CLEANUP_CACHE_ENTRY(frame_pointer);
+	TREF(trig_forced_unwind) = trig_forced_unwind;	/* copy local back to global so "unw_mv_ent" can use that.
+							 * It is safe to do so as long as "unw_mv_ent" has no error codepath
+							 * which is true at this time.
+							 */
 	for (mvc = mv_chain; mvc < (mv_stent *)frame_pointer; )
 	{
 		unw_mv_ent(mvc);
 		mvc = (mv_stent *)(mvc->mv_st_next + (char *)mvc);
 	}
+	TREF(trig_forced_unwind) = FALSE;	/* reset this global right away in case we hit an error codepath below */
 	if (0 <= frame_pointer->dollar_test)		/* get dollar_test if it has been set */
 		dollar_truth = frame_pointer->dollar_test;
 	if (is_tracing_on GTMTRIG_ONLY( && !(frame_pointer->type & SFT_TRIGR)))

--- a/sr_unix/gtm_trigger.c
+++ b/sr_unix/gtm_trigger.c
@@ -810,12 +810,17 @@ int gtm_trigger(gv_trigger_t *trigdsc, gtm_trigger_parms *trigprm)
  */
 void gtm_trigger_fini(boolean_t forced_unwind, boolean_t fromzgoto)
 {
+	DCL_THREADGBL_ACCESS;
+
+	SETUP_THREADGBL_ACCESS;
 	/* Would normally be an assert but potential frame stack damage so severe and resulting debug difficulty that we
 	 * assertpro() instead.
 	 */
 	assertpro(frame_pointer->type & SFT_TRIGR);
+	TREF(trig_forced_unwind) = forced_unwind;	/* used by "op_unwind" */
 	/* Unwind the trigger base frame */
 	op_unwind();
+	assert(FALSE == TREF(trig_forced_unwind));	/* should have been reset by "op_unwind" */
 	/* restore frame_pointer stored at msp (see base_frame.c) */
         frame_pointer = *(stack_frame**)msp;
 	msp += SIZEOF(stack_frame *);           /* Remove frame save pointer from stack */


### PR DESCRIPTION
gtm_trigger_fini() is passed a parameter indicating whether the unwind is forced or not.
But this information is not currently passed to op_unwind() and in turn unw_mv_ent()
which is where the MVST_TRIGR mv_stent is unwound. As part of that unwind, we currently
reset the condition handler stack unconditionally (active_ch, ctxt etc.). But this is
not the right thing to do if the unwind is not forced. An example invocation is from
mdb_condition_handler() using the TRIGGER_BASE_FRAME_UNWIND_IF_NOMANSLAND macro (which
will do the trigger base frame unwind if we are in what is defined as the no-mans-land).
In that case, mdb_condition_handler() is about to do an UNWIND soon after the base frame
unwind and will be caught by surprise if the condition handler stack is reset from under
itself (e.g. it would do a longjmp to a different condition handler's jump target which
can cause the process to terminate abnormally with a stack-smashing/SIGABRT/SIG-6 error).

Since op_unwind() and unw_mv_ent() are used in lots of places, the way this parameter
is being passed is through a global TREF(trig_forced_unwind). This is set in
gtm_trigger_fini() just before the call to op_unwind() and that resets it right away
and uses a local copy to set this global just before invoking unw_mv_ent(). This way
we do not need to worry about resetting this global in case of an error codepath.