### PR TITLE
Change Dockerfile to run ydb script instead of gtm script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,4 +66,4 @@ ENV gtmdir=/data \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
-ENTRYPOINT ["/opt/yottadb/current/gtm"]
+ENTRYPOINT ["/opt/yottadb/current/ydb"]


### PR DESCRIPTION
The gtm script is a symlink to the ydb script for compatibility
purposes only. Update the docker file to use the script directly
instead of relying upon the symlink.