### PR TITLE
[#184] C program that invokes call-ins should undo any terminal characteristic changes when process exits

### DIFF
--- a/sr_unix/continue_handler.c
+++ b/sr_unix/continue_handler.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2013 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2013 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -55,8 +58,6 @@ void continue_handler(int sig, siginfo_t *info, void *context)
 			 * suspended and being continued. SE 7/01
 			 */
 			send_msg(VARLSTCNT(4) ERR_REQ2RESUME, 2, sig_info.send_pid, sig_info.send_uid);
-			if (NULL != io_std_device.in && tt == io_std_device.in->type)
-				setterm(io_std_device.in);
 			/* Fall through */
 		case DEFER_SUSPEND:
 			/* If suspend was deferred, this continue/resume overrides/cancels it */

--- a/sr_unix/dm_read.c
+++ b/sr_unix/dm_read.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -200,6 +203,7 @@ void	dm_read (mval *v)
 	active_device = io_curr_device.in;
 	io_ptr = io_curr_device.in;
 	tt_ptr = (d_tt_struct *)(io_ptr->dev_sp);
+	SETTERM_IF_NEEDED(io_ptr, tt_ptr);
 	assert (io_ptr->state == dev_open);
 	if (tt == io_curr_device.out->type)
 		iott_flush(io_curr_device.out);

--- a/sr_unix/iott_open.c
+++ b/sr_unix/iott_open.c
@@ -141,9 +141,6 @@ short iott_open(io_log_name *dev_name, mval *pp, int fd, mval *mspace, int4 time
 			if (gtm_isanlp(tt_ptr->fildes) == 0)
 				rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCGETATTR, 1, tt_ptr->fildes, save_errno);
 		}
-		if (IS_GTM_IMAGE)
-			/* Only the true runtime runs with the modified terminal settings */
-			setterm(ioptr);
 		status = getcaps(tt_ptr->fildes);
 		if (1 != status)
 		{

--- a/sr_unix/iott_rdone.c
+++ b/sr_unix/iott_rdone.c
@@ -91,6 +91,7 @@ int	iott_rdone (mint *v, int4 msec_timeout)	/* timeout in milliseconds */
 	assert(io_ptr->state == dev_open);
 	iott_flush(io_curr_device.out);
 	tt_ptr = (d_tt_struct*) io_ptr->dev_sp;
+	SETTERM_IF_NEEDED(io_ptr, tt_ptr);
 	timer_id = (TID) iott_rdone;
 	*v = -1;
 	dc1 = (char) 17;

--- a/sr_unix/iott_readfl.c
+++ b/sr_unix/iott_readfl.c
@@ -185,6 +185,7 @@ int	iott_readfl(mval *v, int4 length, int4 msec_timeout)	/* timeout in milliseco
 	io_ptr = io_curr_device.in;
 	ESTABLISH_RET_GTMIO_CH(&io_curr_device, -1, ch_set);
 	tt_ptr = (d_tt_struct *)(io_ptr->dev_sp);
+	SETTERM_IF_NEEDED(io_ptr, tt_ptr);
 	assert(dev_open == io_ptr->state);
 	iott_flush(io_curr_device.out);
 	insert_mode = !(TT_NOINSERT & tt_ptr->ext_cap);	/* get initial mode */

--- a/sr_unix/iott_use.c
+++ b/sr_unix/iott_use.c
@@ -453,7 +453,10 @@ void iott_use(io_desc *iod, mval *pp)
 		temp_ptr = (d_tt_struct *)d_in->dev_sp;
 		Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno);
 		if (0 != status)
+		{
+			assert(FALSE);
 			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
+		}
 		if (tt == d_in->type)
 		{
 			temp_ptr->term_ctrl = mask_in;

--- a/sr_unix/iott_write.c
+++ b/sr_unix/iott_write.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2015 Fidelity National Information 	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -117,6 +120,7 @@ void iott_write(mstr *v)
 		str = v->addr;
 		io_ptr = io_curr_device.out;
 		tt_ptr = (d_tt_struct *)io_ptr->dev_sp;
+		SETTERM_IF_NEEDED(io_ptr, tt_ptr);
 		if (tt_ptr->mupintr)
 			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) ERR_ZINTRECURSEIO);
 		ESTABLISH_GTMIO_CH(&io_curr_device, ch_set);

--- a/sr_unix/resetterm.c
+++ b/sr_unix/resetterm.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2015 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -16,6 +19,7 @@
 
 #include "gtm_termios.h"
 #include "gtm_signal.h"	/* for SIGPROCMASK used inside Tcsetattr */
+#include "gtm_unistd.h"
 
 #include "io.h"
 #include "iottdef.h"
@@ -23,6 +27,8 @@
 #include "eintr_wrappers.h"
 #include "setterm.h"
 #include "gtm_isanlp.h"
+
+GBLREF	uint4		process_id;
 
 error_def(ERR_TCSETATTR);
 
@@ -33,16 +39,22 @@ void  resetterm(io_desc *iod)
 	struct termios 	t;
 	d_tt_struct	*ttptr;
 
-	ttptr =(d_tt_struct *) iod->dev_sp;
+	ttptr = (d_tt_struct *) iod->dev_sp;
+	if (process_id != ttptr->setterm_done_by)
+		return;	/* "resetterm" already done */
 	if (ttptr->ttio_struct)
 	{
 	        t = *ttptr->ttio_struct;
 		Tcsetattr(ttptr->fildes, TCSANOW, &t, status, save_errno);
-		if (status != 0)
+		if (0 != status)
 		{
-			if (gtm_isanlp(ttptr->fildes) == 0)
+			assert(-1 == status);
+			assert(ENOTTY != save_errno);
+			/* Skip TCSETATTR error for ENOTTY (in case fildes is no longer a terminal) */
+			if ((ENOTTY != save_errno) && (0 == gtm_isanlp(ttptr->fildes)))
 				rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, ttptr->fildes, save_errno);
 		}
+		ttptr->setterm_done_by = 0;
 	}
 	return;
 }


### PR DESCRIPTION
There are two issues.

1. At process startup, YottaDB currently changes a few terminal characteristics
   if the principal device is a terminal. But if a C program that invokes a call-in is
   how the YottaDB initialization occurred, process exit currently does not reset these
   characteristics. This leaves the terminal in a weird state. For example, character
   echo is disabled etc. A "stty sane" is needed to get the terminal back to normal.
   This is an issue in GT.M and is reported at https://sourceforge.net/p/fis-gtm/bugs/60/.

2. The terminal changes are actually needed in case a READ or WRITE from/to the terminal
   (including direct mode) happens. But this is done unconditionally. This is best avoided.

The fixes are

1. Fix io_rundown to do a resetterm() in case process is exiting and we do not do a close
   of the terminal device (due to caller invoking this with RUNDOWN_EXCEPT_STD.

2. Do not do setterm() at iott_open() time. Instead defer it as much as possible.
   Invoke setterm() at various points (iott_rdone.c, iott_readfl.c, iott_write.c)
   to do the terminal characteristics changes using the new SETTERM_IF_NEEDED macro.
   setterm() is changed to check if the changes have already been done and if so
   return right away. Similar changes are done to resetterm(). A pid is stored in
   the new field tt_ptr->setterm_done_by (instead of a boolean value) to identify in
   case of ojstartchild() whether the child or the parent did the setterm() (and hence
   needs to do the resetterm()). op_zedit() and op_zsystem() are fixed to do the right
   checks (new macro IS_SETTERM_DONE) for whether a setterm()/resetterm() are needed.
   continue_handler() did a setterm() which seemed incorrect so that has been removed.