### PR TITLE
[#186] Drive ctrl-C handlers correctly, don't dispatch M handlers in direct mode

### DIFF
--- a/sr_port/mdb_condition_handler.c
+++ b/sr_port/mdb_condition_handler.c
@@ -666,7 +666,7 @@ CONDITION_HANDLER(mdb_condition_handler)
 		if (!repeat_error)
 			/* This has already been done if we are re-throwing the error */
 			outofband_clear();
-		if (!trans_action && !ctrlc_on && !(frame_pointer->type & SFT_DM))
+		if (!trans_action && !dm_action && !(frame_pointer->type & SFT_DM))
 		{
 			if (!repeat_error)
 			{


### PR DESCRIPTION
This reverts a change made in GTM-8003 for V6.2-000. But the v62000/gtm8003 test still passes without it.