### PR TITLE
Fail the cmake build if there is an error in the mumps.cmake custom command invocation

### DIFF
--- a/sr_unix/mumps.cmake
+++ b/sr_unix/mumps.cmake
@@ -36,4 +36,9 @@ execute_process(
   COMMAND ${mumps} ${args}
   ${input_file}
   ${output_file}
+  RESULT_VARIABLE res_var
   )
+if(NOT "${res_var}" STREQUAL "0")
+  # do something here about the failed "process" call...
+  message(FATAL_ERROR "Command <${mumps} ${args} ${input_file} ${output_file}> failed with result ='${res_var}'")
+endif()


### PR DESCRIPTION
Below is an example build where gde.m had an error which was logged in the build log.

```
	i $p($zs,",",3,999)[="-E-IOEOF, Attempt to read past an end-of-file" d
		At column 22, line 67, source module /Distrib/YottaDB/V998/dbg/GDE.m
%YDB-E-RHMISSING, Right-hand side of expression expected
```

But the build incorrectly ran fine (0 exit status) due to lack of error checking
in the mumps.cmake script.