### PR TITLE
[#210] Disable M IO for source server and receiver server before redirecting their stdin/stdout/sdterr or else error messages from them might not show up in their log files

### DIFF
--- a/sr_port/op_fnzsocket.c
+++ b/sr_port/op_fnzsocket.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2014-2015 Fidelity National Information 	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -43,7 +46,7 @@ GBLREF spdesc		stringpool;
 GBLREF io_pair		io_curr_device;
 GBLREF io_log_name	*io_root_log_name;
 GBLREF d_socket_struct	*socket_pool;
-GBLREF io_pair		*io_std_device;
+GBLREF io_pair		io_std_device;
 GBLREF io_log_name	*dollar_principal;
 GBLREF mstr		dollar_prin_log;
 GBLREF mstr		dollar_zpin;			/* contains "< /" */
@@ -186,7 +189,7 @@ void	op_fnzsocket(UNIX_ONLY_COMMA(int numarg) mval *dst, ...)
 		iod = io_curr_device.in;
 	else
 	{
-		if ((io_std_device->in != io_std_device->out))
+		if ((io_std_device.in != io_std_device.out))
 		{
 			tlp = dollar_principal ? dollar_principal : io_root_log_name->iod->trans_name;
 			nlen = tlp->len;
@@ -228,8 +231,8 @@ void	op_fnzsocket(UNIX_ONLY_COMMA(int numarg) mval *dst, ...)
 		iod = nl->iod;
 	}
 	/* if iod is standard in device and it is a split device and it is $ZPOUT set iod to output device */
-	if ((2 == nldone) && (io_std_device->in == iod))
-		iod = io_std_device->out;
+	if ((2 == nldone) && (io_std_device.in == iod))
+		iod = io_std_device.out;
 	if (gtmsocket != iod->type)
 	{
 		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) ERR_ZSOCKETNOTSOCK);

--- a/sr_port/op_open.c
+++ b/sr_port/op_open.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -52,7 +52,6 @@ GBLREF uint4		dollar_trestart;
 GBLREF io_log_name	*io_root_log_name;
 GBLREF bool		licensed;
 GBLREF int4		lkid, lid;
-GBLREF io_pair		*io_std_device;
 GBLREF io_log_name	*dollar_principal;
 GBLREF mstr		dollar_zpin;			/* contains "< /" */
 GBLREF mstr		dollar_zpout;			/* contains "> /" */

--- a/sr_port/op_svget.c
+++ b/sr_port/op_svget.c
@@ -97,7 +97,7 @@ GBLREF size_t		totalUsedGta;
 GBLREF mstr		dollar_zchset;
 GBLREF mstr		dollar_zpatnumeric;
 GBLREF boolean_t	dollar_zquit_anyway;
-GBLREF io_pair		*io_std_device;
+GBLREF io_pair		io_std_device;
 GBLREF mstr		dollar_zpin;
 GBLREF mstr		dollar_zpout;
 GBLREF int		process_exiting;
@@ -179,7 +179,7 @@ void op_svget(int varnum, mval *v)
 			break;
 		case SV_ZPIN:
 			/* if not a split device then ZPIN and ZPOUT will fall through to ZPRINCIPAL */
-			if (io_std_device->in != io_std_device->out)
+			if (io_std_device.in != io_std_device.out)
 			{
 				tl = dollar_principal ? dollar_principal : io_root_log_name->iod->trans_name;
 				/* will define zpin as $p contents followed by "< /", for instance: /dev/tty4< / */
@@ -197,7 +197,7 @@ void op_svget(int varnum, mval *v)
 			}
 		case SV_ZPOUT:
 			/* if not a split device then ZPOUT will fall through to ZPRINCIPAL */
-			if (io_std_device->in != io_std_device->out)
+			if (io_std_device.in != io_std_device.out)
 			{
 				tl = dollar_principal ? dollar_principal : io_root_log_name->iod->trans_name;
 				/* will define zpout as $p contents followed by "> /", for instance: /dev/tty4> / */

--- a/sr_port/op_use.c
+++ b/sr_port/op_use.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2015 Fidelity National Information 	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -21,7 +24,7 @@ GBLREF io_pair		io_curr_device;
 GBLREF io_desc		*active_device;
 GBLREF io_log_name	*dollar_principal;
 GBLREF io_log_name	*io_root_log_name;	/* root of linked list	*/
-GBLREF io_pair		*io_std_device;
+GBLREF io_pair		io_std_device;
 GBLREF mstr		dollar_prin_log;
 GBLREF mstr	dollar_zpin;			/* contains "< /" */
 GBLREF mstr	dollar_zpout;			/* contains "> /" */
@@ -44,7 +47,7 @@ void op_use(mval *v, mval *p)
 	MV_FORCE_STR(p);
 
 	dollar_zpselect = 0;
-	if (io_std_device->in != io_std_device->out)
+	if (io_std_device.in != io_std_device.out)
 	{
 		/* if there is a split $P then determine from the name if it is the value of "$P< /" or "$P> /"
 		   if the first then it is $ZPIN so set dollar_zpselect to 1

--- a/sr_port/stp_gcol_src.h
+++ b/sr_port/stp_gcol_src.h
@@ -108,7 +108,7 @@ GBLREF int4			LVGC_interval;				/* dead data GC done every LVGC_interval stringp
 GBLREF boolean_t		suspend_lvgcol;
 GBLREF hash_table_str		*complits_hashtab;
 GBLREF mval			*alias_retarg;
-GBLREF io_pair			*io_std_device;
+GBLREF io_pair			io_std_device;
 GTMTRIG_ONLY(GBLREF mval 	dollar_ztwormhole;)
 DEBUG_ONLY(GBLREF   boolean_t	ok_to_UNWIND_in_exit_handling;)
 
@@ -685,7 +685,7 @@ void stp_gcol(size_t space_asked)	/* BYPASSOK */
 				MSTR_STPG_ADD(&l->iod->error_handler);
 				/* If this is a split $principal, protect error_handler defined on the output side */
 				if ((l->iod->pair.in != l->iod->pair.out)
-				    && (l->iod->pair.out == io_std_device->out))
+				    && (l->iod->pair.out == io_std_device.out))
 					MSTR_STPG_ADD(&l->iod->pair.out->error_handler);
 				rm_ptr = (rm == l->iod->type) ? (d_rm_struct *)l->iod->dev_sp : NULL;
 				if (NULL != rm_ptr)

--- a/sr_port/zshow_svn.c
+++ b/sr_port/zshow_svn.c
@@ -151,7 +151,7 @@ GBLREF mval		dollar_zdir;
 GBLREF mval		dollar_zproc;
 GBLREF stack_frame	*frame_pointer;
 GBLREF io_pair		io_curr_device;
-GBLREF io_pair		*io_std_device;
+GBLREF io_pair		io_std_device;
 GBLREF io_log_name	*io_root_log_name;
 GBLREF io_log_name	*dollar_principal;
 GBLREF mval		dollar_zgbldir;
@@ -632,7 +632,7 @@ void zshow_svn(zshow_out *output, int one_sv)
 				break;
 		/* CAUTION: fall through */
 		case SV_ZPIN:
-			if (io_std_device->in != io_std_device->out)
+			if (io_std_device.in != io_std_device.out)
 			{	/* ZPIN != ZPOUT print it */
 				ZWRITE_SPLIT_DOLLAR_P(var, zdir_error, ZDIR_ERR_LEN, x, dollar_zpin, principalin_text, output);
 			} else if (SV_ALL != one_sv)
@@ -651,7 +651,7 @@ void zshow_svn(zshow_out *output, int one_sv)
 				break;
 		/* CAUTION: fall through */
 		case SV_ZPOUT:
-			if (io_std_device->in != io_std_device->out)
+			if (io_std_device.in != io_std_device.out)
 			{	/* ZPOUT != ZPIN print it */
 				ZWRITE_SPLIT_DOLLAR_P(var, zdir_error, ZDIR_ERR_LEN, x, dollar_zpout, principalout_text, output);
 			} else if (SV_ALL != one_sv)

--- a/sr_unix/gtmrecv.c
+++ b/sr_unix/gtmrecv.c
@@ -62,6 +62,7 @@
 #include "mutex.h"
 #include "fork_init.h"
 #include "gtmio.h"
+#include "io.h"
 
 GBLDEF	boolean_t		gtmrecv_fetchreysnc;
 GBLDEF	boolean_t		gtmrecv_logstats = FALSE;
@@ -83,6 +84,8 @@ GBLREF	boolean_t		holds_sem[NUM_SEM_SETS][NUM_SRC_SEMS];
 GBLREF	jnlpool_addrs_ptr_t	jnlpool;
 GBLREF	IN_PARMS		*cli_lex_in_ptr;
 GBLREF	uint4			mutex_per_process_init_pid;
+GBLREF	io_pair			io_std_device;
+
 LITREF	gtmImageName		gtmImageNames[];
 
 error_def(ERR_YDBDISTUNVERIF);
@@ -386,6 +389,7 @@ int gtmrecv(void)
 		gtmrecv_exit(gtmrecv_showbacklog() - NORMAL_SHUTDOWN);
 	else
 		gtmrecv_exit(gtmrecv_statslog() - NORMAL_SHUTDOWN);
+	io_std_device.out = NULL;	/* See comment in gtmsource.c (has similar initialization) for why this is needed) */
 	/* Point stdin to /dev/null */
 	OPENFILE("/dev/null", O_RDONLY, null_fd);
 	if (0 > null_fd)

--- a/sr_unix/gtmsource.c
+++ b/sr_unix/gtmsource.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2018 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -65,6 +65,7 @@
 #include "gtm_zlib.h"
 #include "fork_init.h"
 #include "gtmio.h"
+#include "io.h"
 #ifdef GTM_TLS
 #include "gtm_repl.h"
 #endif
@@ -103,6 +104,7 @@ GBLREF	gd_region		*ftok_sem_reg;
 GBLREF	boolean_t		holds_sem[NUM_SEM_SETS][NUM_SRC_SEMS];
 GBLREF	IN_PARMS		*cli_lex_in_ptr;
 GBLREF	uint4			mutex_per_process_init_pid;
+GBLREF	io_pair			io_std_device;
 
 error_def(ERR_JNLPOOLSETUP);
 error_def(ERR_MUPCLIERR);
@@ -281,6 +283,16 @@ int gtmsource()
 		 */
 		gtmsource_exit(isalive ? SRV_ALIVE : SRV_ERR);
 	}
+	/* At this point, the parent source server startup command would have done an "io_init" and attached to
+	 * fds = 0, 1 and 2. The child source server is going to close fd=0 here (i.e. point to /dev/null) and
+	 * about to close 1 and 2 a little later in repl_log_init (i.e. point to the source server log file).
+	 * Therefore any io initializations done in io_init (e.g. io_std_device etc.) are soon going to become
+	 * invalid. Since io_std_device.out is checked in the "util_out_print_vaparm" function to decide whether
+	 * to use M IO (write through the device opened by io_init) vs writing directly to stderr (fd=2), it is
+	 * best to clear io_std_device.out for the child process. That way any errors in case they occur go to
+	 * stderr (if available) instead of /dev/null.
+	 */
+	io_std_device.out = NULL;
 	/* Point stdin to /dev/null */
 	OPENFILE("/dev/null", O_RDONLY, null_fd);
 	if (0 > null_fd)

--- a/sr_unix/zshow_devices.c
+++ b/sr_unix/zshow_devices.c
@@ -54,7 +54,7 @@ static readonly char	space_text[] = {' '};
 
 GBLREF boolean_t	ctrlc_on, gtm_utf8_mode;
 GBLREF io_log_name	*io_root_log_name;
-GBLREF io_pair		*io_std_device;
+GBLREF io_pair		io_std_device;
 GBLREF int		process_exiting;
 
 LITREF mstr		chset_names[];
@@ -199,7 +199,7 @@ void zshow_devices(zshow_out *output)
 					}
 				} else
 				{	/* plan to process the output side of $principal if it is std out */
-					if (l->iod->pair.out == io_std_device->out)
+					if (l->iod->pair.out == io_std_device.out)
 						savel = l;
 					tiod = l->iod;
 					v.str.addr = &l->dollar_io[0];
@@ -222,7 +222,7 @@ void zshow_devices(zshow_out *output)
 				case tt:
 					ZS_STR_OUT(&v, terminal_text);
 					tt_ptr = (d_tt_struct*)tiod->dev_sp;
-					if (!ctrlc_on && io_std_device->out == tiod) /* and standard input */
+					if (!ctrlc_on && io_std_device.out == tiod) /* and standard input */
 					{	ZS_PARM_SP(&v, zshow_nocene);
 					}
 					if (tt_ptr->enbld_outofbands.mask)


### PR DESCRIPTION
Due to code changes in GT.M V6.3-004, fd=0 (stdin) was being duped to a fd that
points to /dev/null. But io_init has already happened in the parent source server
startup command process and so any errors (NULLCOLLDIFF error does a gtm_putmsg_csa)
go through util_out_print_vaparm() eventually which incorrectly decides to use the
M device for writing the error (that still points to stdin i.e. fd=0 which was the
terminal at source server startup but has now been redirected to /dev/null later).
Therefore, the error message ends up nowhere. But the source server startup fails
and the user has no clue why it failed. Errors that could be missed out are
NULLCOLLDIFF, REPLOFFJNLON, REPLINSTNOHIST etc.

A workaround for this issue in V6.3-004 is to redirect stdin to say /dev/null as part of
the source server startup command. This would cause the device corresponding to stdout
to be opened as the M device at io_init time thereby causing the error to be written
through fd=1 which is okay since fd=1 has been redirected to the source server log file.

Similar issue exists with the receiver server except that it does not issue any
errors with gtm_putmsg_csa() like the source server in the early stages of the startup
and so that is not as user-visible an issue as the source server one.

While at this, noticed "io_std_device" is a structure global variable that is declared
as GBLREF *io_std_device in some modules and GBLREF io_std_device in most other modules.
Not sure how this works fine but have made it consistent by making it all the latter.