### PR TITLE
[#215] Enhance DEFERRED_EXIT_HANDLING_CHECK macro to handle not just deferred signals that terminate the process but also those that suspend the process (Ctrl-Z)

### DIFF
--- a/sr_port/gtm_malloc_src.h
+++ b/sr_port/gtm_malloc_src.h
@@ -789,7 +789,7 @@ void *gtm_malloc(size_t size)	/* Note renamed to gtm_malloc_dbg when included in
 			TRACE_MALLOC(retVal, size, smTn);
 			--gtmMallocDepth;
 			--fast_lock_count;
-			DEFERRED_EXIT_HANDLING_CHECK;
+			DEFERRED_SIGNAL_HANDLING_CHECK;
 			PTHREAD_MUTEX_UNLOCK_IF_NEEDED(was_holder);	/* release exclusive thread lock if needed */
 			return retVal;
 		} else  /* Storage mgmt has not been initialized */
@@ -1025,7 +1025,7 @@ void gtm_free(void *addr)	/* Note renamed to gtm_free_dbg when included in gtm_m
 		gtm_free_dbg(addr);
 	}
 #	endif
-	DEFERRED_EXIT_HANDLING_CHECK;
+	DEFERRED_SIGNAL_HANDLING_CHECK;
 }
 
 /* When an out-of-storage type error is encountered, besides releasing our memory reserve, we also
@@ -1096,7 +1096,7 @@ void raise_gtmmemory_error(void)	/* Note renamed to raise_gtmmemory_error_dbg wh
 		} else
 			--gtmMallocDepth;
 		--fast_lock_count;
-		DEFERRED_EXIT_HANDLING_CHECK;
+		DEFERRED_SIGNAL_HANDLING_CHECK;
 		was_holder = TRUE; /* caller (gtm_malloc/gtm_free) got the thread lock so release it before the rts_error */
 		PTHREAD_MUTEX_UNLOCK_IF_NEEDED(was_holder);	/* release exclusive thread lock if needed */
 		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(5) ERR_MEMORY, 2, gtmMallocErrorSize, gtmMallocErrorCallerid,

--- a/sr_port/secshr_db_clnup.c
+++ b/sr_port/secshr_db_clnup.c
@@ -554,7 +554,7 @@ void secshr_db_clnup(enum secshr_db_state secshr_state)
 			jnlpool = save_jnlpool;
 		}
 		/* It is possible we are exiting while in the middle of a transaction (e.g. called through "deferred_signal_handler"
-		 * in the DEFERRED_EXIT_HANDLING_CHECK macro). Since exit handling code can start new non-TP transactions
+		 * in the DEFERRED_SIGNAL_HANDLING_CHECK macro). Since exit handling code can start new non-TP transactions
 		 * (e.g. for statsdb rundown you need to kill ^%YGS node, for recording mprof stats you need to set a global node)
 		 * clean up the effects of any in-progress transaction before the "t_begin" call happens.
 		 */

--- a/sr_port/t_end.c
+++ b/sr_port/t_end.c
@@ -1771,7 +1771,7 @@ skip_cr_array:
 	assert(!csa->now_crit || csa->hold_onto_crit);
 	assert(cdb_sc_normal == status);
 	REVERT;	/* no need for t_ch to be invoked if any errors occur after this point */
-	DEFERRED_EXIT_HANDLING_CHECK; /* now that all crits are released, check if deferred signal/exit handling needs to be done */
+	DEFERRED_SIGNAL_HANDLING_CHECK; /* now that crits are released, check if deferred signal/exit handling needs to be done */
 	assert(update_trans);
 	if (REPL_ALLOWED(csa) && IS_DSE_IMAGE)
 	{
@@ -1849,7 +1849,7 @@ failed_skip_revert:
 	 * is if hold_onto_crit is set to TRUE in which case t_commit_cleanup honors it. Assert accordingly.
 	 */
 	assert(!csa->now_crit || !NEED_TO_RELEASE_CRIT(t_tries, status) || csa->hold_onto_crit);
-	DEFERRED_EXIT_HANDLING_CHECK; /* now that all crits are released, check if deferred signal/exit handling needs to be done */
+	DEFERRED_SIGNAL_HANDLING_CHECK; /* now that crits are released, check if deferred signal/exit handling needs to be done */
 	t_retry(status);
 	/* Note that even though cw_stagnate is used only in the final retry, it is possible we restart in the final retry
 	 * (see "final_retry_ok" codes in cdb_sc_table.h) and so a CWS_RESET is necessary in that case. It is anyways a no-op

--- a/sr_port/tp_tend.c
+++ b/sr_port/tp_tend.c
@@ -1878,7 +1878,7 @@ failed:
 	}
 skip_failed:
 	REVERT;
-	DEFERRED_EXIT_HANDLING_CHECK; /* now that all crits are released, check if deferred signal/exit handling needs to be done */
+	DEFERRED_SIGNAL_HANDLING_CHECK; /* now that crits are released, check if deferred signal/exit handling needs to be done */
 	if (cdb_sc_normal == status)
 	{
 		if (save_jnlpool != jnlpool)

--- a/sr_unix/gtm_multi_thread.c
+++ b/sr_unix/gtm_multi_thread.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2015 Fidelity National Information 		*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -20,7 +23,7 @@
 
 #include "gtm_multi_thread.h"
 #include "iosp.h"		/* for SS_NORMAL */
-#include "have_crit.h"		/* for DEFERRED_EXIT_HANDLING_CHECK */
+#include "have_crit.h"		/* for DEFERRED_SIGNAL_HANDLING_CHECK */
 #include "gtmimagename.h"
 #ifdef DEBUG
 #include "wbox_test_init.h"
@@ -175,7 +178,7 @@ int	gtm_multi_thread(gtm_pthread_fnptr_t fnptr, int ntasks, int max_threads,
 		}
 	}
 	multi_thread_in_use = FALSE;
-	DEFERRED_EXIT_HANDLING_CHECK; /* Now that all threads have terminated, check for need of deferred signal/exit handling */
+	DEFERRED_SIGNAL_HANDLING_CHECK; /* Now that all threads have terminated, check for need of deferred signal/exit handling */
 	rc = pthread_attr_destroy(&attr);	/* Free attribute */
 	if (rc)
 		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(8)

--- a/sr_unix/op_fnfgncal.c
+++ b/sr_unix/op_fnfgncal.c
@@ -613,12 +613,12 @@ STATICFNDEF void op_fgnjavacal(mval *dst, mval *package, mval *extref, uint4 mas
 #endif
 	save_mumps_status = mumps_status; 	/* Save mumps_status as a callin from external call may change it. */
 	save_in_ext_call = TREF(in_ext_call);
-	assert(INTRPT_OK_TO_INTERRUPT == intrpt_ok_state);		/* Expected for DEFERRED_EXIT_HANDLING_CHECK below */
+	assert(INTRPT_OK_TO_INTERRUPT == intrpt_ok_state);		/* Expected for DEFERRED_SIGNAL_HANDLING_CHECK below */
 	TREF(in_ext_call) = TRUE;
 	status = callg((callgfnptr)entry_ptr->fcn, param_list);
 	TREF(in_ext_call) = save_in_ext_call;
 	if (!save_in_ext_call)
-		DEFERRED_EXIT_HANDLING_CHECK;					/* Check for deferred wcs_stale() timer */
+		DEFERRED_SIGNAL_HANDLING_CHECK;					/* Check for deferred wcs_stale() timer */
 	mumps_status = save_mumps_status;
 	/* The first byte of the type description argument gets set to 0xFF in case error happened in JNI glue code,
 	 * so check for that and act accordingly.

--- a/sr_unix/rel_crit.c
+++ b/sr_unix/rel_crit.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -81,7 +84,5 @@ void	rel_crit(gd_region *reg)
 	} else
 		CRIT_TRACE(csa, crit_ops_nocrit);
 	/* Now that crit for THIS region is released, check if deferred signal/exit handling can be done and if so do it */
-	DEFERRED_EXIT_HANDLING_CHECK;
-	if ((DEFER_SUSPEND == suspend_status) && OK_TO_INTERRUPT)
-		suspend(SIGSTOP);
+	DEFERRED_SIGNAL_HANDLING_CHECK;
 }

--- a/sr_unix/rel_lock.c
+++ b/sr_unix/rel_lock.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -85,7 +88,5 @@ void	rel_lock(gd_region *reg)
 	} else
 		CRIT_TRACE(csa, crit_ops_nocrit);
 	/* Now that crit for THIS region is released, check if deferred signal/exit handling can be done and if so do it */
-	DEFERRED_EXIT_HANDLING_CHECK;
-	if ((DEFER_SUSPEND == suspend_status) && OK_TO_INTERRUPT)
-		suspend(SIGSTOP);
+	DEFERRED_SIGNAL_HANDLING_CHECK;
 }


### PR DESCRIPTION
In the v63004/gtm8791 subtest, it was noticed that a Ctrl-Z was not handled
(i.e. the process was not suspended) when the test ran on slower systems.
Turns out it was because when the LKE> prompt was being displayed, interrupts
are deferred in the process and if a Ctrl-Z is done at that time, we set
the global variable "suspend_status" to DEFER_SUSPEND to record this fact
and continue but once the interrupts are enabled, we only do checks of deferred
exit handling signals, not of the suspend signal. This means the Ctrl-Z is
effectively ignored. At least until the next rel_crit/rel_lock happens in this
process since that is when the "suspend_status" global is checked again. This
is unfriendly so the DEFERRED_EXIT_HANDLING_CHECK macro (which is invoked every
time we come out of an interrupt deferred zone) is renamed as
DEFERRED_SIGNAL_HANDLING_CHECK and Ctrl-Z deferral is also checked as part of
this macro.