### PR TITLE
Fix spelling in README.md "how to build" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ versions of packages from the distribution repositories.
 
 ## How to build
 
-1. Fulfill the pre-requisites
+1. Fulfill the prerequisites
 
-   Install developement libraries
+   Install development libraries
 
    ```sh
     Ubuntu Linux OR Raspbian Linux OR Beagleboard Debian


### PR DESCRIPTION
"Development" was misspelled as "developement" and "prerequisite" as "pre-requisite." See https://www.merriam-webster.com/dictionary/prerequisite

Thanks much!