### PR TITLE
[#207] Some more fixes to TPRESTART syslog message accuracy

### DIFF
--- a/sr_port/gdsfhead.h
+++ b/sr_port/gdsfhead.h
@@ -1764,6 +1764,7 @@ enum tp_ntp_blkmod_type		/* used for accounting in cs_data->tp_cdb_sc_blkmod[] *
 	tp_blkmod_t_qread,
 	tp_blkmod_tp_tend,
 	tp_blkmod_tp_hist,
+	tp_blkmod_op_tcommit,
 	n_tp_blkmod_types,
 	/* NON-TP transactions */
 	t_blkmod_nomod,

--- a/sr_port/gvcst_expand_key.h
+++ b/sr_port/gvcst_expand_key.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2016 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -95,6 +95,12 @@ GBLREF	sgmnt_data_ptr_t	cs_data;
 #		endif
 #		ifdef GVCST_EXPAND_CURR_KEY
 		/* This means the block changed since we did the search. Return abnormal status so retry occurs. */
+		if (dollar_tlevel)
+			TP_TRACE_HIST_MOD(pStat->blk_num, pStat->blk_target, tp_blkmod_gvcst_srch,
+					  pStat->blk_target->gd_csa->hdr, pStat->tn, ((blk_hdr_ptr_t)pStat->buffaddr)->tn,
+					  pStat->level);
+		else
+			NONTP_TRACE_HIST_MOD(pStat, t_blkmod_gvcst_srch);
 		return cdb_sc_blkmod;
 #		endif
 	}

--- a/sr_port/op_tcommit.c
+++ b/sr_port/op_tcommit.c
@@ -480,6 +480,17 @@ enum cdb_sc	op_tcommit(void)
 			if (cdb_sc_normal != status)
 			{
 				t_fail_hist[t_tries] = status;
+				if (cdb_sc_blkmod == status)
+				{	/* It is possible the call to "t_qread" (in "bm_getfree" or in "op_tcommit")
+					 * caused the cdb_sc_blkmod status. In this case, it would have invoked the
+					 * TP_TRACE_HIST_MOD macro to note down restart related details but would have
+					 * used a blkmod type of "tp_blkmod_t_qread". But we need to differentiate this
+					 * from a call to "t_qread" outside of the TCOMMIT which can cause the same blkmod.
+					 * Hence using a separate type (tp_blkmod_op_tcommit) to indicate this is a call
+					 * to "t_qread" inside "op_tcommit".
+					 */
+					TREF(blkmod_fail_type) = tp_blkmod_op_tcommit;
+				}
 				SET_WC_BLOCKED_FINAL_RETRY_IF_NEEDED(csa, cnl, status);
 				TP_RETRY_ACCOUNTING(csa, cnl);
 			}


### PR DESCRIPTION
* The TPRESTART syslog message relies on all cdb_sc_blkmod occurrences invoking the
  TP_TRACE_HIST_MOD macro. One case in gvcst_expand_key.h was missed out. Now fixed.
  The user-visible impact of this is that some L type of restarts in TP could
  print a potentially incorrect "type:" field because the type was not set as part of
  the current restart (but are using a leftover value of TREF(blkmod_fail_type) from a
  prior restart in the same process).

* In case a cdb_sc_blkmod happens in op_tcommit, it used to be classified as a
  tp_blkmod_t_qread which is misleading since this is not the usual invocation of
  "t_qread" before the TCOMMIT command. So make this a new type "tp_blkmod_op_tcommit".
  This is now recognized by tp_restart() to decide whether to print unsubscripted
  gvn or not in the TPRESTART syslog message. This would make the TPRESTART syslog
  message more fine-grained in terms of the type of restart.

* In tp_hist & tp_tend, the global variable TREF(tprestart_syslog_delta) was used in
  various places. This is now speeded up by copying this into a local variable.
  Additionally, a check of "1 != n_blkmods" is now made debug-only. The if block would
  have always been skipped for a pro build.

* Comments in tp_restart have been enhanced.