### PR TITLE
[#233] Reduce IO impact of MUPIP REORG with new -REORG_SLEEP_NSEC qualifier

### DIFF
--- a/sr_armv7l/GTMDefinedTypesInitDebug.m
+++ b/sr_armv7l/GTMDefinedTypesInitDebug.m
@@ -28198,7 +28198,7 @@ Init
 	Set gtmtypfldindx("sgmnt_addrs","jnlpool")=156
 	;
 	Set gtmtypes("sgmnt_data")="struct"
-	Set gtmtypes("sgmnt_data",0)=593
+	Set gtmtypes("sgmnt_data",0)=594
 	Set gtmtypes("sgmnt_data","len")=8192
 	Set gtmtypes("sgmnt_data",1,"name")="sgmnt_data.label"
 	Set gtmtypes("sgmnt_data",1,"off")=0
@@ -31176,11 +31176,16 @@ Init
 	Set gtmtypes("sgmnt_data",592,"len")=440
 	Set gtmtypes("sgmnt_data",592,"type")="char"
 	Set gtmtypfldindx("sgmnt_data","filler_7k")=592
-	Set gtmtypes("sgmnt_data",593,"name")="sgmnt_data.filler_8k"
+	Set gtmtypes("sgmnt_data",593,"name")="sgmnt_data.reorg_sleep_nsec"
 	Set gtmtypes("sgmnt_data",593,"off")=7168
-	Set gtmtypes("sgmnt_data",593,"len")=1024
-	Set gtmtypes("sgmnt_data",593,"type")="char"
-	Set gtmtypfldindx("sgmnt_data","filler_8k")=593
+	Set gtmtypes("sgmnt_data",593,"len")=4
+	Set gtmtypes("sgmnt_data",593,"type")="unsigned-int"
+	Set gtmtypfldindx("sgmnt_data","reorg_sleep_nsec")=593
+	Set gtmtypes("sgmnt_data",594,"name")="sgmnt_data.filler_8k"
+	Set gtmtypes("sgmnt_data",594,"off")=7172
+	Set gtmtypes("sgmnt_data",594,"len")=1020
+	Set gtmtypes("sgmnt_data",594,"type")="char"
+	Set gtmtypfldindx("sgmnt_data","filler_8k")=594
 	;
 	Set gtmtypes("shm_forw_multi_t")="struct"
 	Set gtmtypes("shm_forw_multi_t",0)=20
@@ -31357,7 +31362,7 @@ Init
 	Set gtmtypes("shm_reg_ctl_t",9,"dim")=3
 	;
 	Set gtmtypes("shm_snapshot_t")="struct"
-	Set gtmtypes("shm_snapshot_t",0)=615
+	Set gtmtypes("shm_snapshot_t",0)=616
 	Set gtmtypes("shm_snapshot_t","len")=12368
 	Set gtmtypes("shm_snapshot_t",1,"name")="shm_snapshot_t.ss_info"
 	Set gtmtypes("shm_snapshot_t",1,"off")=0
@@ -34445,11 +34450,16 @@ Init
 	Set gtmtypes("shm_snapshot_t",614,"len")=440
 	Set gtmtypes("shm_snapshot_t",614,"type")="char"
 	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_7k")=614
-	Set gtmtypes("shm_snapshot_t",615,"name")="shm_snapshot_t.shadow_file_header.filler_8k"
+	Set gtmtypes("shm_snapshot_t",615,"name")="shm_snapshot_t.shadow_file_header.reorg_sleep_nsec"
 	Set gtmtypes("shm_snapshot_t",615,"off")=11344
-	Set gtmtypes("shm_snapshot_t",615,"len")=1024
-	Set gtmtypes("shm_snapshot_t",615,"type")="char"
-	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_8k")=615
+	Set gtmtypes("shm_snapshot_t",615,"len")=4
+	Set gtmtypes("shm_snapshot_t",615,"type")="unsigned-int"
+	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.reorg_sleep_nsec")=615
+	Set gtmtypes("shm_snapshot_t",616,"name")="shm_snapshot_t.shadow_file_header.filler_8k"
+	Set gtmtypes("shm_snapshot_t",616,"off")=11348
+	Set gtmtypes("shm_snapshot_t",616,"len")=1020
+	Set gtmtypes("shm_snapshot_t",616,"type")="char"
+	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_8k")=616
 	;
 	Set gtmtypes("shmpool_blk_hdr")="struct"
 	Set gtmtypes("shmpool_blk_hdr",0)=11
@@ -34511,7 +34521,7 @@ Init
 	Set gtmtypfldindx("shmpool_blk_hdr","image_count")=11
 	;
 	Set gtmtypes("shmpool_buff_hdr")="struct"
-	Set gtmtypes("shmpool_buff_hdr",0)=622
+	Set gtmtypes("shmpool_buff_hdr",0)=623
 	Set gtmtypes("shmpool_buff_hdr","len")=8544
 	Set gtmtypes("shmpool_buff_hdr",1,"name")="shmpool_buff_hdr.shmpool_crit_latch"
 	Set gtmtypes("shmpool_buff_hdr",1,"off")=0
@@ -37634,11 +37644,16 @@ Init
 	Set gtmtypes("shmpool_buff_hdr",621,"len")=440
 	Set gtmtypes("shmpool_buff_hdr",621,"type")="char"
 	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_7k")=621
-	Set gtmtypes("shmpool_buff_hdr",622,"name")="shmpool_buff_hdr.shadow_file_header.filler_8k"
+	Set gtmtypes("shmpool_buff_hdr",622,"name")="shmpool_buff_hdr.shadow_file_header.reorg_sleep_nsec"
 	Set gtmtypes("shmpool_buff_hdr",622,"off")=7520
-	Set gtmtypes("shmpool_buff_hdr",622,"len")=1024
-	Set gtmtypes("shmpool_buff_hdr",622,"type")="char"
-	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_8k")=622
+	Set gtmtypes("shmpool_buff_hdr",622,"len")=4
+	Set gtmtypes("shmpool_buff_hdr",622,"type")="unsigned-int"
+	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.reorg_sleep_nsec")=622
+	Set gtmtypes("shmpool_buff_hdr",623,"name")="shmpool_buff_hdr.shadow_file_header.filler_8k"
+	Set gtmtypes("shmpool_buff_hdr",623,"off")=7524
+	Set gtmtypes("shmpool_buff_hdr",623,"len")=1020
+	Set gtmtypes("shmpool_buff_hdr",623,"type")="char"
+	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_8k")=623
 	;
 	Set gtmtypes("show_reply")="struct"
 	Set gtmtypes("show_reply",0)=2

--- a/sr_armv7l/GTMDefinedTypesInitRelease.m
+++ b/sr_armv7l/GTMDefinedTypesInitRelease.m
@@ -27973,7 +27973,7 @@ Init
 	Set gtmtypfldindx("sgmnt_addrs","jnlpool")=156
 	;
 	Set gtmtypes("sgmnt_data")="struct"
-	Set gtmtypes("sgmnt_data",0)=593
+	Set gtmtypes("sgmnt_data",0)=594
 	Set gtmtypes("sgmnt_data","len")=8192
 	Set gtmtypes("sgmnt_data",1,"name")="sgmnt_data.label"
 	Set gtmtypes("sgmnt_data",1,"off")=0
@@ -30951,11 +30951,16 @@ Init
 	Set gtmtypes("sgmnt_data",592,"len")=440
 	Set gtmtypes("sgmnt_data",592,"type")="char"
 	Set gtmtypfldindx("sgmnt_data","filler_7k")=592
-	Set gtmtypes("sgmnt_data",593,"name")="sgmnt_data.filler_8k"
+	Set gtmtypes("sgmnt_data",593,"name")="sgmnt_data.reorg_sleep_nsec"
 	Set gtmtypes("sgmnt_data",593,"off")=7168
-	Set gtmtypes("sgmnt_data",593,"len")=1024
-	Set gtmtypes("sgmnt_data",593,"type")="char"
-	Set gtmtypfldindx("sgmnt_data","filler_8k")=593
+	Set gtmtypes("sgmnt_data",593,"len")=4
+	Set gtmtypes("sgmnt_data",593,"type")="unsigned-int"
+	Set gtmtypfldindx("sgmnt_data","reorg_sleep_nsec")=593
+	Set gtmtypes("sgmnt_data",594,"name")="sgmnt_data.filler_8k"
+	Set gtmtypes("sgmnt_data",594,"off")=7172
+	Set gtmtypes("sgmnt_data",594,"len")=1020
+	Set gtmtypes("sgmnt_data",594,"type")="char"
+	Set gtmtypfldindx("sgmnt_data","filler_8k")=594
 	;
 	Set gtmtypes("shm_forw_multi_t")="struct"
 	Set gtmtypes("shm_forw_multi_t",0)=20
@@ -31132,7 +31137,7 @@ Init
 	Set gtmtypes("shm_reg_ctl_t",9,"dim")=3
 	;
 	Set gtmtypes("shm_snapshot_t")="struct"
-	Set gtmtypes("shm_snapshot_t",0)=615
+	Set gtmtypes("shm_snapshot_t",0)=616
 	Set gtmtypes("shm_snapshot_t","len")=12368
 	Set gtmtypes("shm_snapshot_t",1,"name")="shm_snapshot_t.ss_info"
 	Set gtmtypes("shm_snapshot_t",1,"off")=0
@@ -34220,11 +34225,16 @@ Init
 	Set gtmtypes("shm_snapshot_t",614,"len")=440
 	Set gtmtypes("shm_snapshot_t",614,"type")="char"
 	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_7k")=614
-	Set gtmtypes("shm_snapshot_t",615,"name")="shm_snapshot_t.shadow_file_header.filler_8k"
+	Set gtmtypes("shm_snapshot_t",615,"name")="shm_snapshot_t.shadow_file_header.reorg_sleep_nsec"
 	Set gtmtypes("shm_snapshot_t",615,"off")=11344
-	Set gtmtypes("shm_snapshot_t",615,"len")=1024
-	Set gtmtypes("shm_snapshot_t",615,"type")="char"
-	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_8k")=615
+	Set gtmtypes("shm_snapshot_t",615,"len")=4
+	Set gtmtypes("shm_snapshot_t",615,"type")="unsigned-int"
+	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.reorg_sleep_nsec")=615
+	Set gtmtypes("shm_snapshot_t",616,"name")="shm_snapshot_t.shadow_file_header.filler_8k"
+	Set gtmtypes("shm_snapshot_t",616,"off")=11348
+	Set gtmtypes("shm_snapshot_t",616,"len")=1020
+	Set gtmtypes("shm_snapshot_t",616,"type")="char"
+	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_8k")=616
 	;
 	Set gtmtypes("shmpool_blk_hdr")="struct"
 	Set gtmtypes("shmpool_blk_hdr",0)=11
@@ -34286,7 +34296,7 @@ Init
 	Set gtmtypfldindx("shmpool_blk_hdr","image_count")=11
 	;
 	Set gtmtypes("shmpool_buff_hdr")="struct"
-	Set gtmtypes("shmpool_buff_hdr",0)=622
+	Set gtmtypes("shmpool_buff_hdr",0)=623
 	Set gtmtypes("shmpool_buff_hdr","len")=8544
 	Set gtmtypes("shmpool_buff_hdr",1,"name")="shmpool_buff_hdr.shmpool_crit_latch"
 	Set gtmtypes("shmpool_buff_hdr",1,"off")=0
@@ -37409,11 +37419,16 @@ Init
 	Set gtmtypes("shmpool_buff_hdr",621,"len")=440
 	Set gtmtypes("shmpool_buff_hdr",621,"type")="char"
 	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_7k")=621
-	Set gtmtypes("shmpool_buff_hdr",622,"name")="shmpool_buff_hdr.shadow_file_header.filler_8k"
+	Set gtmtypes("shmpool_buff_hdr",622,"name")="shmpool_buff_hdr.shadow_file_header.reorg_sleep_nsec"
 	Set gtmtypes("shmpool_buff_hdr",622,"off")=7520
-	Set gtmtypes("shmpool_buff_hdr",622,"len")=1024
-	Set gtmtypes("shmpool_buff_hdr",622,"type")="char"
-	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_8k")=622
+	Set gtmtypes("shmpool_buff_hdr",622,"len")=4
+	Set gtmtypes("shmpool_buff_hdr",622,"type")="unsigned-int"
+	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.reorg_sleep_nsec")=622
+	Set gtmtypes("shmpool_buff_hdr",623,"name")="shmpool_buff_hdr.shadow_file_header.filler_8k"
+	Set gtmtypes("shmpool_buff_hdr",623,"off")=7524
+	Set gtmtypes("shmpool_buff_hdr",623,"len")=1020
+	Set gtmtypes("shmpool_buff_hdr",623,"type")="char"
+	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_8k")=623
 	;
 	Set gtmtypes("show_reply")="struct"
 	Set gtmtypes("show_reply",0)=2

--- a/sr_port/db_auto_upgrade.c
+++ b/sr_port/db_auto_upgrade.c
@@ -204,6 +204,7 @@ void db_auto_upgrade(gd_region *reg)
 		 *    in the last case
 		 * d) Add a new case with the new minor version
 		 * e) Add assert(FALSE) and break (like it was before)
+		 * f) Move this entire comment block (a) thru (f) to just before the newly added "case ...:" block.
 		 */
 			case GDSMR122:
 				/* Nothing to do for this version since it is GDSMVCURR for now. */

--- a/sr_port/db_auto_upgrade.c
+++ b/sr_port/db_auto_upgrade.c
@@ -201,7 +201,6 @@ void db_auto_upgrade(gd_region *reg)
 			case GDSMV63001:
 				/* GT.M V63003 introduced read-only databases */
 				csd->read_only = 0;
-				break;
 			case GDSMV63003:
 				/* YottaDB r122 introduced "reorg_sleep_nsec" to slow down reorg update rate by user */
 				csd->reorg_sleep_nsec = 0;

--- a/sr_port/db_auto_upgrade.c
+++ b/sr_port/db_auto_upgrade.c
@@ -108,14 +108,6 @@ void db_auto_upgrade(gd_region *reg)
 			} else
 				csd->db_got_to_v5_once = TRUE;	/* db was created by V5 so safe to set this */
 		}
-		/* When adding a new minor version, the following template should be maintained
-		 * a) Remove the penultimate 'break'
-		 * b) Remove the assert(FALSE) in the last case (most recent minor version)
-		 * c) If there are any file header fields added in the new minor version, initialize the fields to default values
-		 *    in the last case
-		 * d) Add a new case with the new minor version
-		 * e) Add assert(FALSE) and break (like it was before)
-		 */
 		switch (csd->minor_dbver)
 		{	/* Note that handling for any fields introduced in a version will not go in the "switch-case" block
 			 * of code introduced for the new version but will go in the PREVIOUS "switch-case" block.
@@ -205,6 +197,14 @@ void db_auto_upgrade(gd_region *reg)
 				/* YottaDB r122 introduced "reorg_sleep_nsec" to slow down reorg update rate by user */
 				csd->reorg_sleep_nsec = 0;
 				break;
+		/* When adding a new minor version, the following template should be maintained
+		 * a) Remove the above 'break'
+		 * b) Remove the assert(FALSE) in the last case (not "default:") below (most recent minor version)
+		 * c) If there are any file header fields added in the new minor version, initialize the fields to default values
+		 *    in the last case
+		 * d) Add a new case with the new minor version
+		 * e) Add assert(FALSE) and break (like it was before)
+		 */
 			case GDSMR122:
 				/* Nothing to do for this version since it is GDSMVCURR for now. */
 				assert(FALSE);		/* When this assert fails, it means a new GDSMV* was created, */

--- a/sr_port/db_auto_upgrade.c
+++ b/sr_port/db_auto_upgrade.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -203,6 +203,10 @@ void db_auto_upgrade(gd_region *reg)
 				csd->read_only = 0;
 				break;
 			case GDSMV63003:
+				/* YottaDB r122 introduced "reorg_sleep_nsec" to slow down reorg update rate by user */
+				csd->reorg_sleep_nsec = 0;
+				break;
+			case GDSMR122:
 				/* Nothing to do for this version since it is GDSMVCURR for now. */
 				assert(FALSE);		/* When this assert fails, it means a new GDSMV* was created, */
 				break;			/* 	so a new "case" needs to be added BEFORE the assert. */

--- a/sr_port/dse_dmp_fhead.c
+++ b/sr_port/dse_dmp_fhead.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -245,6 +248,7 @@ void dse_dmp_fhead (void)
 				  ! (RDBF_NOSTATS & csd->reservedDBFlags) ? " TRUE" : "FALSE");
 		util_out_print("  LOCK shares DB critical section     !AD", FALSE, 5, csd->lock_crit_with_db ? " TRUE" : "FALSE");
 		util_out_print("  Read Only                      !AD", TRUE, 3, csd->read_only ? " ON" : "OFF");
+		util_out_print("  Reorg Sleep Nanoseconds !17UL", TRUE, csd->reorg_sleep_nsec);
 	}
 	if (CLI_PRESENT == cli_present("ALL"))
 	{	/* Only dump if -/ALL as if part of above display */

--- a/sr_port/gdsdbver_sp.h
+++ b/sr_port/gdsdbver_sp.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2015-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -33,5 +36,6 @@ ENUM_ENTRY(GDSMV62002),		/* New field defer_allocate needed for database file pr
 ENUM_ENTRY(GDSMV63000),		/* New field non_null_iv to indicate IV mode for encrypted blocks */
 ENUM_ENTRY(GDSMV63000A),	/* Move fields ftok_counter_halted and access_counter_halted from fileheader to nodelocal */
 ENUM_ENTRY(GDSMV63001),		/* New "asyncio" option; New reservedDBFlags field */
-ENUM_ENTRY(GDSMV63003),		/* New field read_only to indicate a read-only database */
+ENUM_ENTRY(GDSMV63003),		/* New field "read_only" to indicate a read-only database */
+ENUM_ENTRY(GDSMR122),		/* New field "reorg_sleep_nsec" to slow down reorg update rate (e.g. reduce restarts) by user */
 ENUM_ENTRY(GDSMVLAST)

--- a/sr_port/gdsfhead.h
+++ b/sr_port/gdsfhead.h
@@ -2175,10 +2175,12 @@ typedef struct sgmnt_data_struct
 	boolean_t	filler_access_counter_halted;	/* Used only in V6.3-000. Kept as a filler just to be safe */
 	boolean_t	lock_crit_with_db;		/* flag controlling LOCK crit mechanism; see interlock.h */
 	uint4		basedb_fname_len;		/* byte length of filename stored in "basedb_fname[]" */
-	unsigned char	basedb_fname[256]; /* full path filaneme of corresponding baseDB if this is a statsDB */
+	unsigned char	basedb_fname[256];	/* full path filaneme of corresponding baseDB if this is a statsDB */
 	boolean_t	read_only;		/* If TRUE, GT.M uses a process-private mmap instead of IPC */
 	char		filler_7k[440];
-	char		filler_8k[1024];
+	/************** YottaDB specific fields *********************/
+	uint4		reorg_sleep_nsec;	/* Time a MUPIP REORG sleeps before starting to process a GDS block */
+	char		filler_8k[1020];
 	/********************************************************/
 	/* Master bitmap immediately follows. Tells whether the local bitmaps have any free blocks or not. */
 } sgmnt_data;

--- a/sr_port/mdef.h
+++ b/sr_port/mdef.h
@@ -1434,7 +1434,7 @@ qw_num	gtm_byteswap_64(qw_num num64);
 #define HOUR			3600	/* one hour in seconds 60 * 60 */
 #define ONEDAY			86400	/* seconds in a day */
 #define MILLISECS_IN_SEC	((int)1E3)	/* millseconds in a second */
-#define MICROSEC_IN_SEC		((int)1E6)	/* microseconds in a second */
+#define MICROSECS_IN_SEC		((int)1E6)	/* microseconds in a second */
 #define MICROSECS_IN_MSEC	((int)1E3)	/* microseconds in a millisecond */
 #define NANOSECS_IN_SEC		((int)1E9)	/* nanoseconds in a second */
 #define NANOSECS_IN_MSEC	((int)1E6)	/* nanoseconds in a millisecond */

--- a/sr_port/mupip_set.c
+++ b/sr_port/mupip_set.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -107,6 +110,7 @@ void mupip_set(void)
 		|| (CLI_PRESENT == cli_present("READ_ONLY"))
 		|| (CLI_NEGATED == cli_present("READ_ONLY"))
 		|| (CLI_PRESENT == cli_present("RECORD_SIZE"))
+		|| (CLI_PRESENT == cli_present("REORG_SLEEP_NSEC"))
 		|| (CLI_PRESENT == cli_present("RESERVED_BYTES"))
 		|| (CLI_PRESENT == cli_present("SLEEP_SPIN_COUNT"))
 		|| (CLI_PRESENT == cli_present("SPIN_SLEEP_MASK"))

--- a/sr_port/repl_comm.c
+++ b/sr_port/repl_comm.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2015 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -153,7 +156,7 @@ int fd_ioready(int sock_fd, int poll_direction, int timeout)
 
 	assert(timeout < MILLISECS_IN_SEC);
 	SELECT_ONLY(timeout = timeout * 1000);		/* Convert to microseconds (~ 1sec) */
-	assert((timeout >= 0) && (timeout < POLL_ONLY(MILLISECS_IN_SEC) SELECT_ONLY(MICROSEC_IN_SEC)));
+	assert((timeout >= 0) && (timeout < POLL_ONLY(MILLISECS_IN_SEC) SELECT_ONLY(MICROSECS_IN_SEC)));
 #	ifdef USE_POLL
 	fds.fd = sock_fd;
 	fds.events = (REPL_POLLIN == poll_direction) ? POLLIN : POLLOUT;

--- a/sr_port/time_calc.c
+++ b/sr_port/time_calc.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -74,10 +77,10 @@ void	add_int_to_abs_time(ABS_TIME *atps, int4 ival,ABS_TIME *atpd)
 	ival_sec  = ival / MILLISECS_IN_SEC;					/* milliseconds -> seconds */
 	ival_usec = (ival - (ival_sec * MILLISECS_IN_SEC)) * MICROSECS_IN_MSEC;	/* microsecond remainder */
 	atpd->at_sec = atps->at_sec + ival_sec;
-	if ((atpd->at_usec = atps->at_usec + ival_usec) >= MICROSEC_IN_SEC)
+	if ((atpd->at_usec = atps->at_usec + ival_usec) >= MICROSECS_IN_SEC)
 	{
 		/* microsecond overflow */
-		atpd->at_usec -= MICROSEC_IN_SEC;
+		atpd->at_usec -= MICROSECS_IN_SEC;
 		atpd->at_sec  += 1;		/* carry */
 	}
 }
@@ -107,7 +110,7 @@ ABS_TIME	sub_abs_time(ABS_TIME *atp1, ABS_TIME *atp2)
 
 	if (atp2->at_usec > atp1->at_usec)
 	{
-		dat.at_usec += MICROSEC_IN_SEC;
+		dat.at_usec += MICROSECS_IN_SEC;
 		dat.at_sec--;
 	}
 	return (dat);

--- a/sr_unix/gt_timers.c
+++ b/sr_unix/gt_timers.c
@@ -758,10 +758,10 @@ STATICFNDEF void timer_handler(int why)
 					rel_time = sub_abs_time(&at, &old_at);
 					late_time.at_sec += rel_time.at_sec;
 					late_time.at_usec += rel_time.at_usec;
-					if (late_time.at_usec > MICROSEC_IN_SEC)
+					if (late_time.at_usec > MICROSECS_IN_SEC)
 					{
 						late_time.at_sec++;
-						late_time.at_usec -= MICROSEC_IN_SEC;
+						late_time.at_usec -= MICROSECS_IN_SEC;
 					}
 #					endif
 				}

--- a/sr_unix/gtm_rel_quant.h
+++ b/sr_unix/gtm_rel_quant.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -51,8 +54,7 @@ MBSTART {												\
 		NANO_SLEEP_TIME = (process_id ^ (TIME_ADJ++)) & (MAX_TIME_MASK);			\
 		if (!NANO_SLEEP_TIME)									\
 			NANO_SLEEP_TIME = MAX_TIME_MASK;						\
-		assert((NANO_SLEEP_TIME < E_9) && (NANO_SLEEP_TIME > 0));				\
-		NANOSLEEP(NANO_SLEEP_TIME, FALSE);							\
+		NANOSLEEP(NANO_SLEEP_TIME, RESTART_FALSE);						\
 	} else												\
 		RELQUANT;										\
 } MBEND

--- a/sr_unix/gtmrecv_fetchresync.c
+++ b/sr_unix/gtmrecv_fetchresync.c
@@ -65,7 +65,7 @@
 
 #define MAX_ATTEMPTS_FOR_FETCH_RESYNC	60 /* max-wait in seconds for source server response after connection is established */
 #define MAX_WAIT_FOR_FETCHRESYNC_CONN	60 /* max-wait in seconds to establish connection with the source server */
-#define FETCHRESYNC_PRIMARY_POLL	(MICROSEC_IN_SEC - 1) /* micro seconds, almost 1 second */
+#define FETCHRESYNC_PRIMARY_POLL	(MICROSECS_IN_SEC - 1) /* micro seconds, almost 1 second */
 
 #define CHECK_SEND_RECV_LOOP_ERROR(STATUS, WAIT_COUNT, MESSAGE)									\
 {																\

--- a/sr_unix/mupip_cmd.c
+++ b/sr_unix/mupip_cmd.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2018 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -721,9 +724,10 @@ static	CLI_ENTRY	mup_set_qual[] = {
 { "PARTIAL_RECOV_BYPASS", mupip_set, 0, 0,			0,				0, 0, VAL_DISALLOWED, 1, NON_NEG, VAL_N_A,  0 },
 { "PREVJNLFILE",          mupip_set, 0, 0,			0,				0, 0, VAL_REQ,        1, NEG,     VAL_STR,  0 },
 { "QDBRUNDOWN",           mupip_set, 0, 0,			0,				0, 0, VAL_DISALLOWED, 1, NEG,     VAL_N_A,  0 },
-{ "READ_ONLY",            mupip_set, 0, 0,                  0,                    0, 0, VAL_DISALLOWED, 1, NEG,     VAL_N_A,  0 },
+{ "READ_ONLY",            mupip_set, 0, 0,                      0,                              0, 0, VAL_DISALLOWED, 1, NEG,     VAL_N_A,  0 },
 { "RECORD_SIZE",          mupip_set, 0, 0,			0,				0, 0, VAL_REQ,        1, NON_NEG, VAL_NUM,  0 },
 { "REGION",               mupip_set, 0, 0,			0,				0, 0, VAL_DISALLOWED, 1, NON_NEG, VAL_N_A,  0 },
+{ "REORG_SLEEP_NSEC",     mupip_set, 0, 0,			0,				0, 0, VAL_REQ,        1, NON_NEG, VAL_NUM,  VAL_DCM },
 { "REPLICATION",          mupip_set, 0, 0,			mup_repl_qual,			0, 0, VAL_REQ,        1, NEG,     VAL_STR,  0 },
 { "REPL_STATE",           mupip_set, 0, 0,			0,				0, 0, VAL_REQ,        1, NEG,     VAL_STR,  0 },
 { "RESERVED_BYTES",       mupip_set, 0, 0,			0,				0, 0, VAL_REQ,        1, NON_NEG, VAL_NUM,  0 },

--- a/sr_unix/op_zut.c
+++ b/sr_unix/op_zut.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2015 Fidelity National Information 		*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -27,7 +30,7 @@ void op_zut(mval *s)
 	int4		pwr;
 
 	assertpro(-1 != gettimeofday(&tv, NULL));
-	microseconds = (1LL * MICROSEC_IN_SEC * tv.tv_sec) + tv.tv_usec;
+	microseconds = (1LL * MICROSECS_IN_SEC * tv.tv_sec) + tv.tv_usec;
 	if ((microseconds < 0) && (microseconds > E_18))
 		rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) ERR_WEIRDSYSTIME);
 	if (microseconds < E_6)

--- a/sr_unix/sleep.h
+++ b/sr_unix/sleep.h
@@ -16,6 +16,9 @@
 #ifndef SLEEP_H
 #define SLEEP_H
 
+#define	RESTART_FALSE	FALSE
+#define	RESTART_TRUE	TRUE
+
 /* Note: GT.M code *MUST NOT* use the sleep function because it causes problems with GT.M's timers on some platforms. Specifically,
  * the sleep function results in SIGARLM handler being silently deleted on Solaris systems (through Solaris 9 at least). This leads
  * to lost timer pops and has the potential for system hangs. The proper long sleep mechanism is hiber_start which can be accessed
@@ -28,121 +31,10 @@
 
 void m_usleep(int useconds);
 
-#if !defined(_AIX) && !defined(__osf__) && !defined(__sparc) && !defined(_UWIN) && !defined(__linux__)
-#   if !defined(__MVS__) && !defined(__CYGWIN__) && !defined(__hpux)
+#if !defined(__linux__)
 #      error "Unsure of support for sleep functions on this platform"
-#   endif
 #endif
 
-#if defined(__MVS__) || defined(__CYGWIN__) || defined(__hpux) || defined(_AIX)
-/* For HP-UX the clock_* seem to be missing; for AIX the accuracy of clock_* is currently poor */
-#define SET_EXPIR_TIME(NOW_TIMEVAL, EXPIR_TIMEVAL, SECS, USECS)				\
-MBSTART {										\
-	gettimeofday(&(NOW_TIMEVAL), NULL);						\
-	if (E_6 <= ((NOW_TIMEVAL).tv_usec + USECS))					\
-	{										\
-		(EXPIR_TIMEVAL).tv_sec = (NOW_TIMEVAL).tv_sec + (SECS) + 1;		\
-		(EXPIR_TIMEVAL).tv_usec = (NOW_TIMEVAL).tv_usec + (USECS) - E_6;	\
-	} else										\
-	{										\
-		(EXPIR_TIMEVAL).tv_sec = (NOW_TIMEVAL).tv_sec + (SECS);			\
-		(EXPIR_TIMEVAL).tv_usec = (NOW_TIMEVAL).tv_usec + (USECS);		\
-	}										\
-} MBEND
-
-/* This macro *does not* have surrounding braces and *will break* out of the block it is in on non-positive remaining time. */
-#define UPDATE_REM_TIME_OR_BREAK(NOW_TIMEVAL, EXPIR_TIMEVAL, SECS, USECS)		\
-	gettimeofday(&(NOW_TIMEVAL), NULL);						\
-	if (((NOW_TIMEVAL).tv_sec > (EXPIR_TIMEVAL).tv_sec)				\
-		|| (((NOW_TIMEVAL).tv_sec == (EXPIR_TIMEVAL).tv_sec)			\
-			&& ((NOW_TIMEVAL).tv_usec >= (EXPIR_TIMEVAL).tv_usec)))		\
-		break;									\
-	if ((EXPIR_TIMEVAL).tv_usec < (NOW_TIMEVAL).tv_usec)				\
-	{										\
-		SECS = (time_t)((EXPIR_TIMEVAL).tv_sec - (NOW_TIMEVAL).tv_sec - 1);	\
-		USECS = (int)(E_6 + (EXPIR_TIMEVAL).tv_usec - (NOW_TIMEVAL).tv_usec);	\
-	} else										\
-	{										\
-		SECS = (time_t)((EXPIR_TIMEVAL).tv_sec - (NOW_TIMEVAL).tv_sec);		\
-		USECS = (int)((EXPIR_TIMEVAL).tv_usec - (NOW_TIMEVAL).tv_usec);		\
-	}										\
-
-#if defined(__MVS__) || defined(__CYGWIN__)
-/* On z/OS neither clock_nanosleep nor nanosleep is available, so use a combination of sleep, usleep, and gettimeofday instead.
- * Since we do not have a z/OS box presently, this implementation has not been tested, and so it likely needs some casts at the very
- * least. Another note is that sleep is unsafe to mix with timers on other platforms, but on z/OS the documentation does not mention
- * any fallouts, so this should be verified. If it turns out that sleep is unsafe, we might have to use pthread_cond_timewait or
- * call usleep (which, given that we have used it on z/OS before, should be safe) in a loop.
- * Due to the above stated limitations the minimum sleep on z/OS is 1 Usec
- * cywin is a mystery so assume the worst */
-#define SLEEP_USEC(MICROSECONDS, RESTART)						\
-MBSTART {										\
-	int 		secs, interrupted;						\
-	useconds_t	usecs;								\
-	struct timeval	now, expir;							\
-											\
-	assert(0 < MICROSECONDS);							\
-	secs = (MICROSECONDS) / 1000;							\
-	usecs = (MICROSECONDS) % E_6;							\
-	SET_EXPIR_TIME(now, expir, secs, usecs);					\
-	if (RESTART)									\
-	{										\
-		while (0 < secs)							\
-		{									\
-			sleep(secs);		/* BYPASSOK */				\
-			/* This macro will break the loop when it is time. */		\
-			UPDATE_REM_TIME_OR_BREAK(now, expir, secs, usecs);		\
-		}									\
-		while (0 < usecs)							\
-		{									\
-			usleep(usecs);							\
-			/* This macro will break the loop when it is time. */		\
-			UPDATE_REM_TIME_OR_BREAK(now, expir, secs, usecs);		\
-		}									\
-	} else										\
-	{										\
-		interrupted = sleep(secs);	/* BYPASSOK */				\
-		if (!interrupted)							\
-		{	/* This macro will break the loop when it is time. */		\
-			UPDATE_REM_TIME_OR_BREAK(now, expir, secs, usecs);		\
-			usleep(usecs);							\
-		}									\
-	}										\
-} MBEND
-#else
-
-/* For most UNIX platforms a combination of nanosleep() and gettimeofday() proved to be the most supported, accurate, and
- * operationally sound approach. Alternatives for implementing high-resolution sleeps include clock_nanosleep() and nsleep()
- */
-#  define SLEEP_USEC(MICROSECONDS, RESTART)						\
-MBSTART {										\
-	int 		status, usecs;							\
-	struct timespec	req;								\
-	struct timeval	now, expir;							\
-											\
-	assert(0 < MICROSECONDS);							\
-	req.tv_sec = (time_t)((MICROSECONDS) / E_6);					\
-	req.tv_nsec = ((usecs = (MICROSECONDS) % E_6) * 1000); /* Assignment! */	\
-	assert(E_9 > req.tv_nsec);							\
-	if (RESTART)									\
-	{										\
-		SET_EXPIR_TIME(now, expir, req.tv_sec, usecs);				\
-		while ((-1 == (status = nanosleep(&req, NULL))) && (EINTR == errno))	\
-		{	/* This macro will break the loop when it is time. */		\
-			UPDATE_REM_TIME_OR_BREAK(now, expir, req.tv_sec, usecs);	\
-			req.tv_nsec = (usecs * 1000);					\
-		}									\
-	} else										\
-		nanosleep(&req, NULL);							\
-} MBEND
-#endif
-
-# define NANOSLEEP(NANOSECONDS, RESTART)						\
-MBSTART {										\
-	SLEEP_USEC((1000 > (NANOSECONDS)) ? 1 : ((NANOSECONDS) / 1000), RESTART);	\
-} MBEND
-#endif
-#if !defined(__MVS__) && !defined(__CYGWIN__) && !defined(__hpux)
 /* Nonetheless, because we continue to press for the highest time discrimination available, where posible we use
  * clock_nanosleep and clock_gettime, which, while currently no faster than gettimeofday(), do eventually promise
  * sub-millisecond accuracy
@@ -159,10 +51,10 @@ MBSTART {											\
 	assert(0 < (NANOSECONDS));								\
 	clock_gettime(CLOCK_MONOTONIC, &REQTIM);						\
 	REQTIM.tv_nsec += (long)(NANOSECONDS);							\
-	if (E_9 <= REQTIM.tv_nsec)								\
+	if (NANOSECS_IN_SEC <= REQTIM.tv_nsec)							\
 	{											\
-		REQTIM.tv_sec += (time_t)(REQTIM.tv_nsec / E_9);				\
-		REQTIM.tv_nsec %= E_9;								\
+		REQTIM.tv_sec += (time_t)(REQTIM.tv_nsec / NANOSECS_IN_SEC);			\
+		REQTIM.tv_nsec %= NANOSECS_IN_SEC;						\
 	}											\
 	do											\
 	{											\
@@ -173,16 +65,16 @@ MBSTART {											\
 	} while (TRUE);										\
 } MBEND
 
-#if !defined(_AIX)
-# define SLEEP_USEC(MICROSECONDS, RESTART)						\
-MBSTART {										\
-	NANOSLEEP(((MICROSECONDS) * 1000), RESTART);					\
+# define SLEEP_USEC(MICROSECONDS, RESTART)					\
+MBSTART {									\
+	assert((MICROSECS_IN_SEC > MICROSECONDS) && (0 < MICROSECONDS));	\
+	NANOSLEEP(((MICROSECONDS) * 1000), RESTART);				\
 } MBEND
 
-# define NANOSLEEP(NANOSECONDS, RESTART)						\
-MBSTART {										\
-	CLOCK_NANOSLEEP(NANOSECONDS, RESTART);					\
+# define NANOSLEEP(NANOSECONDS, RESTART)				\
+MBSTART {								\
+	assert((NANOSECS_IN_SEC > NANOSECONDS) && (0 < NANOSECONDS));	\
+	CLOCK_NANOSLEEP(NANOSECONDS, RESTART);				\
 } MBEND
-#endif
-#endif
+
 #endif /* SLEEP_H */

--- a/sr_x86_64/GTMDefinedTypesInitDebug.m
+++ b/sr_x86_64/GTMDefinedTypesInitDebug.m
@@ -28143,7 +28143,7 @@ Init
 	Set gtmtypfldindx("sgmnt_addrs","jnlpool")=155
 	;
 	Set gtmtypes("sgmnt_data")="struct"
-	Set gtmtypes("sgmnt_data",0)=593
+	Set gtmtypes("sgmnt_data",0)=594
 	Set gtmtypes("sgmnt_data","len")=8192
 	Set gtmtypes("sgmnt_data",1,"name")="sgmnt_data.label"
 	Set gtmtypes("sgmnt_data",1,"off")=0
@@ -31121,11 +31121,16 @@ Init
 	Set gtmtypes("sgmnt_data",592,"len")=440
 	Set gtmtypes("sgmnt_data",592,"type")="char"
 	Set gtmtypfldindx("sgmnt_data","filler_7k")=592
-	Set gtmtypes("sgmnt_data",593,"name")="sgmnt_data.filler_8k"
+	Set gtmtypes("sgmnt_data",593,"name")="sgmnt_data.reorg_sleep_nsec"
 	Set gtmtypes("sgmnt_data",593,"off")=7168
-	Set gtmtypes("sgmnt_data",593,"len")=1024
-	Set gtmtypes("sgmnt_data",593,"type")="char"
-	Set gtmtypfldindx("sgmnt_data","filler_8k")=593
+	Set gtmtypes("sgmnt_data",593,"len")=4
+	Set gtmtypes("sgmnt_data",593,"type")="unsigned-int"
+	Set gtmtypfldindx("sgmnt_data","reorg_sleep_nsec")=593
+	Set gtmtypes("sgmnt_data",594,"name")="sgmnt_data.filler_8k"
+	Set gtmtypes("sgmnt_data",594,"off")=7172
+	Set gtmtypes("sgmnt_data",594,"len")=1020
+	Set gtmtypes("sgmnt_data",594,"type")="char"
+	Set gtmtypfldindx("sgmnt_data","filler_8k")=594
 	;
 	Set gtmtypes("shm_forw_multi_t")="struct"
 	Set gtmtypes("shm_forw_multi_t",0)=20
@@ -31302,7 +31307,7 @@ Init
 	Set gtmtypes("shm_reg_ctl_t",9,"dim")=3
 	;
 	Set gtmtypes("shm_snapshot_t")="struct"
-	Set gtmtypes("shm_snapshot_t",0)=615
+	Set gtmtypes("shm_snapshot_t",0)=616
 	Set gtmtypes("shm_snapshot_t","len")=12376
 	Set gtmtypes("shm_snapshot_t",1,"name")="shm_snapshot_t.ss_info"
 	Set gtmtypes("shm_snapshot_t",1,"off")=0
@@ -34390,11 +34395,16 @@ Init
 	Set gtmtypes("shm_snapshot_t",614,"len")=440
 	Set gtmtypes("shm_snapshot_t",614,"type")="char"
 	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_7k")=614
-	Set gtmtypes("shm_snapshot_t",615,"name")="shm_snapshot_t.shadow_file_header.filler_8k"
+	Set gtmtypes("shm_snapshot_t",615,"name")="shm_snapshot_t.shadow_file_header.reorg_sleep_nsec"
 	Set gtmtypes("shm_snapshot_t",615,"off")=11352
-	Set gtmtypes("shm_snapshot_t",615,"len")=1024
-	Set gtmtypes("shm_snapshot_t",615,"type")="char"
-	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_8k")=615
+	Set gtmtypes("shm_snapshot_t",615,"len")=4
+	Set gtmtypes("shm_snapshot_t",615,"type")="unsigned-int"
+	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.reorg_sleep_nsec")=615
+	Set gtmtypes("shm_snapshot_t",616,"name")="shm_snapshot_t.shadow_file_header.filler_8k"
+	Set gtmtypes("shm_snapshot_t",616,"off")=11356
+	Set gtmtypes("shm_snapshot_t",616,"len")=1020
+	Set gtmtypes("shm_snapshot_t",616,"type")="char"
+	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_8k")=616
 	;
 	Set gtmtypes("shmpool_blk_hdr")="struct"
 	Set gtmtypes("shmpool_blk_hdr",0)=11
@@ -34456,7 +34466,7 @@ Init
 	Set gtmtypfldindx("shmpool_blk_hdr","image_count")=11
 	;
 	Set gtmtypes("shmpool_buff_hdr")="struct"
-	Set gtmtypes("shmpool_buff_hdr",0)=622
+	Set gtmtypes("shmpool_buff_hdr",0)=623
 	Set gtmtypes("shmpool_buff_hdr","len")=8560
 	Set gtmtypes("shmpool_buff_hdr",1,"name")="shmpool_buff_hdr.shmpool_crit_latch"
 	Set gtmtypes("shmpool_buff_hdr",1,"off")=0
@@ -37579,11 +37589,16 @@ Init
 	Set gtmtypes("shmpool_buff_hdr",621,"len")=440
 	Set gtmtypes("shmpool_buff_hdr",621,"type")="char"
 	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_7k")=621
-	Set gtmtypes("shmpool_buff_hdr",622,"name")="shmpool_buff_hdr.shadow_file_header.filler_8k"
+	Set gtmtypes("shmpool_buff_hdr",622,"name")="shmpool_buff_hdr.shadow_file_header.reorg_sleep_nsec"
 	Set gtmtypes("shmpool_buff_hdr",622,"off")=7536
-	Set gtmtypes("shmpool_buff_hdr",622,"len")=1024
-	Set gtmtypes("shmpool_buff_hdr",622,"type")="char"
-	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_8k")=622
+	Set gtmtypes("shmpool_buff_hdr",622,"len")=4
+	Set gtmtypes("shmpool_buff_hdr",622,"type")="unsigned-int"
+	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.reorg_sleep_nsec")=622
+	Set gtmtypes("shmpool_buff_hdr",623,"name")="shmpool_buff_hdr.shadow_file_header.filler_8k"
+	Set gtmtypes("shmpool_buff_hdr",623,"off")=7540
+	Set gtmtypes("shmpool_buff_hdr",623,"len")=1020
+	Set gtmtypes("shmpool_buff_hdr",623,"type")="char"
+	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_8k")=623
 	;
 	Set gtmtypes("show_reply")="struct"
 	Set gtmtypes("show_reply",0)=2

--- a/sr_x86_64/GTMDefinedTypesInitRelease.m
+++ b/sr_x86_64/GTMDefinedTypesInitRelease.m
@@ -27918,7 +27918,7 @@ Init
 	Set gtmtypfldindx("sgmnt_addrs","jnlpool")=155
 	;
 	Set gtmtypes("sgmnt_data")="struct"
-	Set gtmtypes("sgmnt_data",0)=593
+	Set gtmtypes("sgmnt_data",0)=594
 	Set gtmtypes("sgmnt_data","len")=8192
 	Set gtmtypes("sgmnt_data",1,"name")="sgmnt_data.label"
 	Set gtmtypes("sgmnt_data",1,"off")=0
@@ -30896,11 +30896,16 @@ Init
 	Set gtmtypes("sgmnt_data",592,"len")=440
 	Set gtmtypes("sgmnt_data",592,"type")="char"
 	Set gtmtypfldindx("sgmnt_data","filler_7k")=592
-	Set gtmtypes("sgmnt_data",593,"name")="sgmnt_data.filler_8k"
+	Set gtmtypes("sgmnt_data",593,"name")="sgmnt_data.reorg_sleep_nsec"
 	Set gtmtypes("sgmnt_data",593,"off")=7168
-	Set gtmtypes("sgmnt_data",593,"len")=1024
-	Set gtmtypes("sgmnt_data",593,"type")="char"
-	Set gtmtypfldindx("sgmnt_data","filler_8k")=593
+	Set gtmtypes("sgmnt_data",593,"len")=4
+	Set gtmtypes("sgmnt_data",593,"type")="unsigned-int"
+	Set gtmtypfldindx("sgmnt_data","reorg_sleep_nsec")=593
+	Set gtmtypes("sgmnt_data",594,"name")="sgmnt_data.filler_8k"
+	Set gtmtypes("sgmnt_data",594,"off")=7172
+	Set gtmtypes("sgmnt_data",594,"len")=1020
+	Set gtmtypes("sgmnt_data",594,"type")="char"
+	Set gtmtypfldindx("sgmnt_data","filler_8k")=594
 	;
 	Set gtmtypes("shm_forw_multi_t")="struct"
 	Set gtmtypes("shm_forw_multi_t",0)=20
@@ -31077,7 +31082,7 @@ Init
 	Set gtmtypes("shm_reg_ctl_t",9,"dim")=3
 	;
 	Set gtmtypes("shm_snapshot_t")="struct"
-	Set gtmtypes("shm_snapshot_t",0)=615
+	Set gtmtypes("shm_snapshot_t",0)=616
 	Set gtmtypes("shm_snapshot_t","len")=12376
 	Set gtmtypes("shm_snapshot_t",1,"name")="shm_snapshot_t.ss_info"
 	Set gtmtypes("shm_snapshot_t",1,"off")=0
@@ -34165,11 +34170,16 @@ Init
 	Set gtmtypes("shm_snapshot_t",614,"len")=440
 	Set gtmtypes("shm_snapshot_t",614,"type")="char"
 	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_7k")=614
-	Set gtmtypes("shm_snapshot_t",615,"name")="shm_snapshot_t.shadow_file_header.filler_8k"
+	Set gtmtypes("shm_snapshot_t",615,"name")="shm_snapshot_t.shadow_file_header.reorg_sleep_nsec"
 	Set gtmtypes("shm_snapshot_t",615,"off")=11352
-	Set gtmtypes("shm_snapshot_t",615,"len")=1024
-	Set gtmtypes("shm_snapshot_t",615,"type")="char"
-	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_8k")=615
+	Set gtmtypes("shm_snapshot_t",615,"len")=4
+	Set gtmtypes("shm_snapshot_t",615,"type")="unsigned-int"
+	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.reorg_sleep_nsec")=615
+	Set gtmtypes("shm_snapshot_t",616,"name")="shm_snapshot_t.shadow_file_header.filler_8k"
+	Set gtmtypes("shm_snapshot_t",616,"off")=11356
+	Set gtmtypes("shm_snapshot_t",616,"len")=1020
+	Set gtmtypes("shm_snapshot_t",616,"type")="char"
+	Set gtmtypfldindx("shm_snapshot_t","shadow_file_header.filler_8k")=616
 	;
 	Set gtmtypes("shmpool_blk_hdr")="struct"
 	Set gtmtypes("shmpool_blk_hdr",0)=11
@@ -34231,7 +34241,7 @@ Init
 	Set gtmtypfldindx("shmpool_blk_hdr","image_count")=11
 	;
 	Set gtmtypes("shmpool_buff_hdr")="struct"
-	Set gtmtypes("shmpool_buff_hdr",0)=622
+	Set gtmtypes("shmpool_buff_hdr",0)=623
 	Set gtmtypes("shmpool_buff_hdr","len")=8560
 	Set gtmtypes("shmpool_buff_hdr",1,"name")="shmpool_buff_hdr.shmpool_crit_latch"
 	Set gtmtypes("shmpool_buff_hdr",1,"off")=0
@@ -37354,11 +37364,16 @@ Init
 	Set gtmtypes("shmpool_buff_hdr",621,"len")=440
 	Set gtmtypes("shmpool_buff_hdr",621,"type")="char"
 	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_7k")=621
-	Set gtmtypes("shmpool_buff_hdr",622,"name")="shmpool_buff_hdr.shadow_file_header.filler_8k"
+	Set gtmtypes("shmpool_buff_hdr",622,"name")="shmpool_buff_hdr.shadow_file_header.reorg_sleep_nsec"
 	Set gtmtypes("shmpool_buff_hdr",622,"off")=7536
-	Set gtmtypes("shmpool_buff_hdr",622,"len")=1024
-	Set gtmtypes("shmpool_buff_hdr",622,"type")="char"
-	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_8k")=622
+	Set gtmtypes("shmpool_buff_hdr",622,"len")=4
+	Set gtmtypes("shmpool_buff_hdr",622,"type")="unsigned-int"
+	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.reorg_sleep_nsec")=622
+	Set gtmtypes("shmpool_buff_hdr",623,"name")="shmpool_buff_hdr.shadow_file_header.filler_8k"
+	Set gtmtypes("shmpool_buff_hdr",623,"off")=7540
+	Set gtmtypes("shmpool_buff_hdr",623,"len")=1020
+	Set gtmtypes("shmpool_buff_hdr",623,"type")="char"
+	Set gtmtypfldindx("shmpool_buff_hdr","shadow_file_header.filler_8k")=623
 	;
 	Set gtmtypes("show_reply")="struct"
 	Set gtmtypes("show_reply",0)=2


### PR DESCRIPTION
* A new field "reorg_sleep_nsec" is introduced in the database file header (sgmnt_data).
  Any MUPIP REORG process will check this value and if non-zero will sleep for the
  specified # of nanoseconds before processing every block in the database. This field
  can be changed with a MUPIP SET -REORG_SLEEP_NSEC= command which can be run while
  the reorg process is still running (i.e. the command does not require standalone access
  to the database file). This lets the user try out different sleeps in the same reorg
  process in case it runs for a long time.

* DSE DUMP -FILE displays the current setting of reorg_sleep_nsec.

* Because of the new field in the file header, the database minor version needed change.

* And GTMDefinedTypesInit* files needed to be regenerated (to ensure PEEKBYNAME works
  with the new field).

* Changed MICROSEC_IN_SEC -> MICROSECS_IN_SEC to be consistent with MILLISECS_IN_SEC
  and NANOSECS_IN_SEC.

* Moved an assert about range of the input to the NANOSLEEP macro into the macro itself
  so it is centralized instead of duplicated in callers of this macro.

* Simplified sleep.h by removing code corresponding to unsupported platforms.