### PR TITLE
[#235] Ensure source server never terminates with a JNLSWITCHRETRY error

### DIFF
--- a/sr_port/wbox_test_init.h
+++ b/sr_port/wbox_test_init.h
@@ -88,7 +88,7 @@ typedef enum {
 						 *      assert in mur_process_intrpt_recov.c */
 	WBTEST_HOLD_ONTO_FTOKSEM_IN_DBINIT,	/* 49 : Sleep in db_init after getting hold of the ftok semaphore */
 	WBTEST_HOLD_ONTO_ACCSEM_IN_DBINIT,	/* 50 : Sleep in db_init after getting hold of the access control semaphore */
-	WBTEST_JNL_SWITCH_EXPECTED,		/* 51 : We expect an automatic journal file switch in jnl_file_open */
+	WBTEST_UNUSED51,			/* 51 : UNUSED - YDB#235 removed the only place to test this */
 	WBTEST_SYSCONF_WRAPPER,			/* 52 : Will sleep in SYSCONF wrapper to let us verify that first two MUPIP STOPs
 						 *	are indeed deferred in the interrupt-deferred zone, but the third isn't */
         WBTEST_DEFERRED_TIMERS,			/* 53 : Will enter a long loop upon specific WRITE or MUPIP STOP command */

--- a/sr_unix/jnl_file_open.c
+++ b/sr_unix/jnl_file_open.c
@@ -145,17 +145,12 @@ uint4 jnl_file_open(gd_region *reg, boolean_t init)
 				} else
 					sts = jnl_file_open_common(reg, (off_jnl_t) stat_buf.st_size, buff);
 			}
-#			ifdef DEBUG
-			/* Will fail if Source Server would need to switch journal files. */
-			assert((ydb_white_box_test_case_enabled && (WBTEST_JNL_SWITCH_EXPECTED == ydb_white_box_test_case_number))
-					|| (0 == sts) || (!is_src_server));
-#			endif
 			if ((0 != sts) && switch_and_retry)
 			{	/* Switch to a new journal file and retry, but only once */
 				sts = jnl_file_open_switch(reg, sts, buff);
 				if (0 == sts)
 				{
-					switch_and_retry = FALSE;
+					switch_and_retry = FALSE;	/* retry only once */
 					continue;
 				}
 			}


### PR DESCRIPTION
Background
-----------
The v62000_1/gtm8086 subtest failed because the source server terminated prematurely with a JNLSWITCHRETRY error.

The test drives a lot of processes doing updates to the db/jnls with a small autoswitchlimit value so journal file switches happen frequently (once or twice a second).

After one journal switch has happened, the test turns off write permissions to the directory housing the journal files ("jnldir").

Since this test runs with replication and has instance freeze turned on, the test expects the instance to be frozen when a journal switch happens after write permissions have been turned off (that did freeze the instance in this test run).

Soon after the test turns write permissions back on "jnldir".

In this test run though, it so happened that the source server had sent all seqnos until the penultimate generation journal file so it tries to open the latest generation journal file (say JNL1) which is full of data (upto the autoswitch limit).

But before the source server could open JNL1, this journal file JNL1 had just been closed concurrently by another mumps process (in preparing to switch to a new journal file) and the field "is_not_latest_jnl" was set in the jnl file header of JNL1 but the concurrent process encountered an error while trying to create a new generation journal file JNL2 (due to write permissions) so it did not rename the JNL1 file (.mjl --> .mjl_..)

That meant the source server saw JNL1 and wanted to open it ("jnl_file_open_common") but saw the "is_not_latest_jnl" field and issued a JNLSWITCHRETRY error in the source server log and terminated. That in turn caused the test failure.

This is an edge-case code issue in the source server since GT.M V6.3-001A when the JNLSWITCHRETRY error was introduced.

In the case of mumps processes, once they fail the "jnl_file_open_common" call with JNLSWITCHRETRY error, they will try the "jnl_file_open_switch" call but because the instance is frozen, they will hang (trying to create a new journal file will go through LSEEKWRITE which will hang).

But in the case of the source server, we have code in jnl_file_open.c which disables the call to "jnl_file_open_switch" because we decided the source server is a read-only process and should never create journal files.

And so it takes a different codepath which is to print the JNLSWITCHRETRY error.

Fix
----
The source server should not issue the error but instead read from the latest generation journal file as if it is an older generation journal file (since this journal file will never be the currently open journal file in shared memory again) just like it would read from any prior generation journal file.