### PR TITLE
[#197] Fix syntax error in ydb_env_set.gtc (fi in same line as if needs a preceding semicolon)

### DIFF
--- a/sr_unix/ydb_env_set.gtc
+++ b/sr_unix/ydb_env_set.gtc
@@ -30,8 +30,8 @@ fi
 # Save ydb_routines / gtmroutines if defined because
 # this script will overwrite ydb_routines if defined
 # to make sure there is a path to the required routine
-if [ ! -z "$gtmroutines" ] ; then ydb_tmp_routines="$gtmroutines" fi
-if [ ! -z "$ydb_routines" ] ; then ydb_tmp_routines="$ydb_routines" fi
+if [ ! -z "$gtmroutines" ] ; then ydb_tmp_routines="$gtmroutines" ; fi
+if [ ! -z "$ydb_routines" ] ; then ydb_tmp_routines="$ydb_routines" ; fi
 
 # Save environment variables if they exist, which may be needed for tmp and log directories
 if [ ! -z "$ydb_rel" ] ; then export ydb_tmp_rel=$ydb_rel ; fi


### PR DESCRIPTION
Before this fix, the following error used to show up if one sourced ydb_env_set
```
$ . ydb_env_set
sh: 82: ydb_env_set: Syntax error: end of file unexpected (expecting "fi")
```