### PR TITLE
Fix various compiler warnings identified by gcc 8.1

### DIFF
--- a/sr_port/dse_chng_fhead.c
+++ b/sr_port/dse_chng_fhead.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2016 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -229,8 +232,8 @@ void dse_chng_fhead(void)
 					*(qw_num_ptr_t)chng_ptr = value;
 			} else
 				value = old_value;
-			SPRINTF(temp_str1, "Location !UL [0x!XL] : Old Value = %s : New Value = %s : Size = !UB [0x!XB]",
-				temp_str, temp_str);
+			SNPRINTF(temp_str1, SIZEOF(temp_str1),
+				"Location !UL [0x!XL] : Old Value = %s : New Value = %s : Size = !UB [0x!XB]", temp_str, temp_str);
 			if (SIZEOF(int4) >= size)
 				util_out_print(temp_str1, TRUE, location, location, (uint4)old_value, (uint4)old_value,
 					(uint4)value, (uint4)value, size, size);

--- a/sr_port/gtm_string.h
+++ b/sr_port/gtm_string.h
@@ -27,7 +27,7 @@
 #define	STRCPY(DEST, SOURCE)		strcpy((char *)(DEST), (char *)(SOURCE))
 #define STRNCPY_LIT(DEST, LITERAL)	memcpy((char *)(DEST), (char *)(LITERAL), SIZEOF(LITERAL) - 1)	/* BYPASSOK */
 #define STRNCPY_LIT_FULL(DEST, LITERAL)	strncpy((char *)(DEST), (char *)(LITERAL), SIZEOF(LITERAL))	/* BYPASSOK */
-#define	STRNCPY_STR(DEST, STRING, LEN)	SNPRINTF((char *)(DEST), LEN, "%s", (char *)(STRING))
+#define	STRNCPY_STR(DEST, STRING, LEN)	strncpy((char *)(DEST), (char *)(STRING), LEN)
 #define	STRCMP(SOURCE, DEST)		strcmp((char *)(SOURCE), (char *)(DEST))
 #define	STRNCMP_LIT(SOURCE, LITERAL)	strncmp(SOURCE, LITERAL, SIZEOF(LITERAL) - 1)		/* BYPASSOK */
 /* Make sure that SIZEOF(SOURCE) > 0 or SOURCE != NULL before running. */

--- a/sr_port/gtm_string.h
+++ b/sr_port/gtm_string.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  * Copyright (c) 2017 Stephen L Johnson. All rights reserved.	*
@@ -25,9 +25,9 @@
 
 #define STRERROR	strerror
 #define	STRCPY(DEST, SOURCE)		strcpy((char *)(DEST), (char *)(SOURCE))
-#define STRNCPY_LIT(DEST, LITERAL)	strncpy((char *)(DEST), (char *)(LITERAL), SIZEOF(LITERAL) - 1)	/* BYPASSOK */
+#define STRNCPY_LIT(DEST, LITERAL)	memcpy((char *)(DEST), (char *)(LITERAL), SIZEOF(LITERAL) - 1)	/* BYPASSOK */
 #define STRNCPY_LIT_FULL(DEST, LITERAL)	strncpy((char *)(DEST), (char *)(LITERAL), SIZEOF(LITERAL))	/* BYPASSOK */
-#define	STRNCPY_STR(DEST, STRING, LEN)	strncpy((char *)(DEST), (char *)(STRING), LEN)
+#define	STRNCPY_STR(DEST, STRING, LEN)	SNPRINTF((char *)(DEST), LEN, "%s", (char *)(STRING))
 #define	STRCMP(SOURCE, DEST)		strcmp((char *)(SOURCE), (char *)(DEST))
 #define	STRNCMP_LIT(SOURCE, LITERAL)	strncmp(SOURCE, LITERAL, SIZEOF(LITERAL) - 1)		/* BYPASSOK */
 /* Make sure that SIZEOF(SOURCE) > 0 or SOURCE != NULL before running. */

--- a/sr_port/iosocket_listen.c
+++ b/sr_port/iosocket_listen.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2018 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -94,12 +97,8 @@ boolean_t iosocket_listen_sock(socket_struct *socketptr, unsigned short len)
 	dsocketptr->iod->dollar.key[len++] = '|';
 	if (socket_local != socketptr->protocol)
 		SPRINTF(&dsocketptr->iod->dollar.key[len], "%d", socketptr->local.port);
-#	ifndef VMS
 	else
-	{
-		STRNCPY_STR(&dsocketptr->iod->dollar.key[len],
-			((struct sockaddr_un *)(socketptr->local.sa))->sun_path, DD_BUFLEN - len - 1);
-	}
-#	endif
+		SNPRINTF(&dsocketptr->iod->dollar.key[len], DD_BUFLEN - len, "%s",
+					((struct sockaddr_un *)(socketptr->local.sa))->sun_path);
 	return TRUE;
 }

--- a/sr_port/op_fnzsocket.c
+++ b/sr_port/op_fnzsocket.c
@@ -529,13 +529,13 @@ void	op_fnzsocket(UNIX_ONLY_COMMA(int numarg) mval *dst, ...)
 				memcpy(charptr, ONE_COMMA, len);
 				charptr += len;
 				len = SIZEOF(TLSCLIENTSTR) - 1;
-				STRNCPY_STR(charptr, (GTMTLS_OP_CLIENT_MODE & tls_sock->flags) ? TLSCLIENTSTR : TLSSERVERSTR, len);
+				memcpy(charptr, (GTMTLS_OP_CLIENT_MODE & tls_sock->flags) ? TLSCLIENTSTR : TLSSERVERSTR, len);
 				charptr += len;
 				len = STRLEN(tls_sock->tlsid);
 				if (0 < len)
 				{
 					*charptr++ = ',';
-					STRNCPY_STR(charptr, tls_sock->tlsid, len);
+					memcpy(charptr, tls_sock->tlsid, len);
 					charptr += len;
 				}
 				if (0 < len2)
@@ -545,12 +545,12 @@ void	op_fnzsocket(UNIX_ONLY_COMMA(int numarg) mval *dst, ...)
 						STRCPY(charptr, "|P:");
 						charptr += OPTIONPREFIXLEN;
 						len2 = STRLEN(conn_info.protocol);
-						STRNCPY_STR(charptr, conn_info.protocol, len2);
+						memcpy(charptr, conn_info.protocol, len2);
 						charptr += len2;
 						STRCPY(charptr, "|C:");
 						charptr += OPTIONPREFIXLEN;
 						len2 = STRLEN(conn_info.session_algo);
-						STRNCPY_STR(charptr, conn_info.session_algo, len2);
+						memcpy(charptr, conn_info.session_algo, len2);
 						charptr += len2;
 					}
 					if (TLS_OPTIONS_OPTIONS & tls_options_mask)
@@ -580,7 +580,7 @@ void	op_fnzsocket(UNIX_ONLY_COMMA(int numarg) mval *dst, ...)
 							*charptr++ = ',';
 							STRCPY(charptr, "SESSID:");
 							charptr += 7;
-							STRNCPY_STR(charptr, conn_info.session_id, len2);
+							memcpy(charptr, conn_info.session_id, len2);
 							charptr += len2;
 						}
 						if (-1 != conn_info.session_expiry_timeout)

--- a/sr_unix/cli_parse.c
+++ b/sr_unix/cli_parse.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2018 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -589,7 +592,7 @@ boolean_t cli_get_sub_quals(CLI_ENTRY *pparm)
 		while (NULL != ptr_next_val)
 		{
 			len_str= STRLEN(ptr_next_val);
-			strncpy(tmp_str, ptr_next_val, len_str);
+			memcpy(tmp_str, ptr_next_val, len_str);
 			tmp_str[len_str] = 0;
 			tmp_str_ptr = tmp_str;
 			ptr_next_comma = strchr(tmp_str_ptr, ',');

--- a/sr_unix/gtm_tls_impl.c
+++ b/sr_unix/gtm_tls_impl.c
@@ -1349,7 +1349,7 @@ gtm_tls_socket_t *gtm_tls_socket(gtm_tls_ctx_t *tls_ctx, gtm_tls_socket_t *prev_
 	socket->flags = flags;
 	socket->ssl = ssl;
 	socket->gtm_ctx = tls_ctx;
-	strncpy(socket->tlsid, (const char *)id, SIZEOF(socket->tlsid));
+	SNPRINTF(socket->tlsid, SIZEOF(socket->tlsid), "%s", (const char *)id);
 	/* Now, store the `socket' structure in the `SSL' structure so that we can get it back in a callback that receives an
 	 * `SSL' structure. Ideally, we should be using SSL_set_ex_data/SSL_get_ex_data family of functions. But, these functions
 	 * operate on a specific index (obtained by calling SSL_get_ex_new_index). But, since the library should potentially
@@ -1671,7 +1671,7 @@ int gtm_tls_get_conn_info(gtm_tls_socket_t *socket, gtm_tls_conn_info *conn_info
 					assert(FALSE && ssl_version);
 					break;
 			}
-			strncpy(conn_info->protocol, ssl_version_ptr, MAX_ALGORITHM_LEN);
+			SNPRINTF(conn_info->protocol, SIZEOF(conn_info->protocol), "%s", ssl_version_ptr);
 			/* SSL-Session Cipher Algorithm */
 			cipher = SSL_get_current_cipher(ssl);
 			SNPRINTF(conn_info->session_algo, SIZEOF(conn_info->session_algo), "%s", SSL_CIPHER_get_name(cipher));

--- a/sr_unix/gtmcrypt.h
+++ b/sr_unix/gtmcrypt.h
@@ -351,7 +351,7 @@ MBSTART {															\
 					gtmcrypt_badhash_size_msg = (char *)malloc(1024);					\
 				SNPRINTF(gtmcrypt_badhash_size_msg, 1023, "Specified symmetric key hash has "			\
 					"length %d, which is different from the expected hash length %d",			\
-					hash_string.length, GTMCRYPT_HASH_LEN);							\
+					(int)hash_string.length, GTMCRYPT_HASH_LEN);						\
 				RC = SET_CRYPTERR_MASK(ERR_CRYPTHASHGENFAILED);							\
 			} else													\
 			{	/* Note that the copy is not NULL-terminated. */						\

--- a/sr_unix/gtmcrypt_dbk_ref.c
+++ b/sr_unix/gtmcrypt_dbk_ref.c
@@ -208,7 +208,7 @@ int gtmcrypt_getkey_by_hash(unsigned char *hash, char *db_path, gtm_keystore_t *
 					errorlen = STRLEN(gtmcrypt_err_string);
 					if (MAX_GTMCRYPT_ERR_STRLEN < errorlen)
 						errorlen = MAX_GTMCRYPT_ERR_STRLEN;
-					strncpy(save_err, gtmcrypt_err_string, errorlen);
+					memcpy(save_err, gtmcrypt_err_string, errorlen);
 					save_err[errorlen] = '\0';
 					UPDATE_ERROR_STRING("Expected hash - " STR_ARG " - %s. %s",
 						ELLIPSIZE(hex_buff), save_err, alert_msg);
@@ -325,7 +325,7 @@ STATICFNDEF gtm_keystore_t *keystore_lookup_by_keyname_plus(char *keyname, char 
 	ynew_ext = keyname + keynamelen - STRLEN(EXT_NEW);
 	if ((ynew_ext >= keyname) && (0 == strcmp(ynew_ext, EXT_NEW)))
 	{	/* This is an autodb, fixup the path */
-		strncpy(lcl_keyname, keyname, keynamelen - STRLEN(EXT_NEW));
+		memcpy(lcl_keyname, keyname, keynamelen - STRLEN(EXT_NEW));
 		lcl_keyname[keynamelen - STRLEN(EXT_NEW)] = '\0';
 		keyname = lcl_keyname;
 	}
@@ -400,7 +400,7 @@ STATICFNDEF gtm_keystore_t *keystore_lookup_by_unres_key(char *search_field1, in
 				 * is a fully resolved path.
 				 */
 				isautodb = TRUE;
-				strncpy(name_search_field_buff, search_field1, search_field_len - STRLEN(EXT_NEW));
+				memcpy(name_search_field_buff, search_field1, search_field_len - STRLEN(EXT_NEW));
 				name_search_field_buff[search_field_len - STRLEN(EXT_NEW)] = '\0';
 				name_search_field_ptr = name_search_field_buff;
 			}
@@ -659,7 +659,7 @@ STATICFNDEF int keystore_refresh(void)
 			return -1;
 		}
 		/* The ydb_crypt_config variable is defined and accessible. Copy it to a global for future references. */
-		strncpy(gc_config_filename, config_env, YDB_PATH_MAX);
+		SNPRINTF(gc_config_filename, SIZEOF(gc_config_filename), "%s", config_env);
 		just_read = TRUE;
 	}
 	assert(!CONFIG_FILE_UNREAD);
@@ -916,9 +916,9 @@ STATICFNDEF void insert_unresolved_key_link(char *keyname, char *keypath, int in
 
 	node = (gtm_keystore_unres_key_link_t *)MALLOC(SIZEOF(gtm_keystore_unres_key_link_t));
 	memset(node->key_name, 0, YDB_PATH_MAX);
-	strncpy(node->key_name, keyname, YDB_PATH_MAX);
+	SNPRINTF(node->key_name, SIZEOF(node->key_name), "%s", keyname);
 	memset(node->key_path, 0, YDB_PATH_MAX);
-	strncpy(node->key_path, keypath, YDB_PATH_MAX);
+	SNPRINTF(node->key_path, SIZEOF(node->key_path), "%s", keypath);
 	node->next = keystore_by_unres_key_head;
 	node->index = index;
 	node->status = status;

--- a/sr_unix/gtmcrypt_pk_ref.c
+++ b/sr_unix/gtmcrypt_pk_ref.c
@@ -209,7 +209,7 @@ int gc_pk_gpghome_has_permissions()
 			return -1;
 		}
 		gnupghome_set = TRUE;
-		strncpy(pathname, ptr, pathlen);
+		memcpy(pathname, ptr, pathlen);
 		pathname[pathlen] = '\0';
 	}
 	if (-1 != (perms = access(pathname, R_OK | X_OK)))

--- a/sr_unix/gtmcrypt_util.c
+++ b/sr_unix/gtmcrypt_util.c
@@ -274,9 +274,9 @@ int gc_mask_unmask_passwd(int nparm, gtm_string_t *in, gtm_string_t *out)
 			SNPRINTF(tmp, GTM_PASSPHRASE_MAX, "%ld", (long) stat_info.st_ino);
 			len = (int)STRLEN(tmp);
 			if (len < passwd_len)
-				strncpy(hash_in + (passwd_len - len), tmp, len);
+				memcpy(hash_in + (passwd_len - len), tmp, len);
 			else
-				strncpy(hash_in, tmp, passwd_len);
+				memcpy(hash_in, tmp, passwd_len);
 		} else
 		{
 			save_errno = errno;

--- a/sr_unix/jnl_prc_vector.c
+++ b/sr_unix/jnl_prc_vector.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2009 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2009 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -54,23 +57,23 @@ void jnl_prc_vector (jnl_process_vector *pv)
 	GETPWUID(eff_uid, pw);
 	if (pw)
 	{
-		strncpy(pv->jpv_user, pw->pw_name, JPV_LEN_USER);
-		strncpy(pv->jpv_prcnam, pw->pw_name, JPV_LEN_PRCNAM);
-		UNICODE_ONLY(
+		SNPRINTF(pv->jpv_user, SIZEOF(pv->jpv_user), "%s", pw->pw_name);
+		SNPRINTF(pv->jpv_prcnam, SIZEOF(pv->jpv_prcnam), "%s", pw->pw_name);
+#		ifdef UNICODE
 		/* In UTF8 mode, trim the string (if necessary) to contain only as many valid multi-byte characters as can fit in */
 		if (gtm_utf8_mode)
 		{
 			gtm_utf8_trim_invalid_tail((unsigned char *)pv->jpv_user, JPV_LEN_USER);
 			gtm_utf8_trim_invalid_tail((unsigned char *)pv->jpv_prcnam, JPV_LEN_PRCNAM);
 		}
-		)
+#		endif
 	} else
 	{
-		DEBUG_ONLY(
-			strncpy(pv->jpv_user,"ERROR=",JPV_LEN_USER);
-			if (errno < 1000)               /* protect against overflow */
-				c = i2asc((uchar_ptr_t)pv->jpv_user + 6, errno);  /* past = above */
-		)
+#		ifdef DEBUG
+		SNPRINTF(pv->jpv_user, SIZEOF(pv->jpv_user), "%s", "ERROR=");
+		if (errno < 1000)               /* protect against overflow */
+			c = i2asc((uchar_ptr_t)pv->jpv_user + 6, errno);  /* past = above */
+#		endif
 	}
 	endpwent();                        /* close passwd file to free channel */
 	if ((c = (unsigned char *)TTYNAME(0)) != NULL)
@@ -83,6 +86,6 @@ void jnl_prc_vector (jnl_process_vector *pv)
 				break;
 			}
 		}
-		strncpy(pv->jpv_terminal, (char *)s, JPV_LEN_TERMINAL);
+		SNPRINTF(pv->jpv_terminal, SIZEOF(pv->jpv_terminal), "%s", (char *)s);
 	}
 }

--- a/sr_unix/util_output.c
+++ b/sr_unix/util_output.c
@@ -93,19 +93,19 @@ error_def(ERR_TEXT);
 }
 
 /* #GTM_THREAD_SAFE : The below macro (INSERT_MARKER) is thread-safe because caller ensures serialization with locks */
-#define INSERT_MARKER									\
-{											\
-	assert(IS_PTHREAD_LOCKED_AND_HOLDER);						\
-	STRNCPY_STR(offset, "-", STRLEN("-"));						\
-	offset += STRLEN("-");								\
+#define INSERT_MARKER						\
+{								\
+	assert(IS_PTHREAD_LOCKED_AND_HOLDER);			\
+	STRNCPY_LIT(offset, "-");				\
+	offset += STRLEN("-");					\
 }
 
 /* #GTM_THREAD_SAFE : The below macro (BUILD_FACILITY) is thread-safe because caller ensures serialization with locks */
-#define BUILD_FACILITY(strptr)								\
-{											\
-	assert(IS_PTHREAD_LOCKED_AND_HOLDER);						\
-	STRNCPY_STR(offset, strptr, STRLEN(strptr));					\
-	offset += STRLEN(strptr);							\
+#define BUILD_FACILITY(strptr)					\
+{								\
+	assert(IS_PTHREAD_LOCKED_AND_HOLDER);			\
+	memcpy(offset, strptr, STRLEN(strptr));			\
+	offset += STRLEN(strptr);				\
 }
 
 /*


### PR DESCRIPTION
Building with gcc 8.1.0 identified two types of warnings.
```
	a) [-Wstringop-truncation] and
	b) [-Wstringop-overflow=]
```
Example warnings
```
sr_unix/gtmcrypt_pk_ref.c:212:3: warning: 'strncpy' output truncated before terminating
	nul copying as many bytes from a string as its length [-Wstringop-truncation]

sr_unix/gtmcrypt_dbk_ref.c:328:3: warning: 'strncpy' specified bound depends on the
	length of the source argument [-Wstringop-overflow=]
```
Both warnings have to do with strncpy usages. The fix to strncpy usages was two-fold.

1) If "strncpy" is used to copy an exact number of bytes (e.g. if the exact number
   was determined only a few lines above using strlen()), then the strncpy was replaced
   with a memcpy since we don't need to do a copy looking for a terminating null byte.

2) If "strncpy" is used to ensure we never overflow the destination buffer, then we
   use SNPRINTF (macro which translates to an EINTR-safe snprintf() invocation) to
   ensure the null byte is copied too after any needed truncation of the input string.
   strncpy only does the truncation and does not copy the null byte whereas snprintf
   does both.

In addition, a use of SPRINTF in dse_chng_fhead.c was replaced with SNPRINTF since the
compiler identified this as a case of a possible overflow. And a parameter
"hash_string.length" with a type "long unsigned int" passed to SNPRINTF macro in
gtmcrypt.h was typecast to (int) to avoid a type mismatch compiler warning.