### PR TITLE
[#215] Trim down size of libyottadb.so more than it had bloated in prior #215 commit

### DIFF
--- a/sr_port/gbldefs.c
+++ b/sr_port/gbldefs.c
@@ -412,7 +412,7 @@ GBLDEF	volatile int4		gtmMallocDepth;		/* Recursion indicator */
 GBLDEF	d_socket_struct		*socket_pool;
 GBLDEF	boolean_t		mu_star_specified;
 GBLDEF	backup_reg_list		*mu_repl_inst_reg_list;
-GBLDEF	volatile int		suspend_status = NO_SUSPEND;
+GBLDEF	volatile int		is_suspended;		/* TRUE if this process is currently suspended */
 GBLDEF	gv_namehead		*reset_gv_target = INVALID_GV_TARGET;
 GBLDEF	VSIG_ATOMIC_T		util_interrupt;
 GBLDEF	sgmnt_addrs		*kip_csa;
@@ -1228,3 +1228,6 @@ GBLDEF	int4		tstart_gtmci_nested_level;	/* TREF(gtmci_nested_level) at the time 
 							 * This should be used only if dollar_tlevel is non-zero as it is not
 							 * otherwise maintained.
 							 */
+GBLDEF	boolean_t	deferred_signal_handling_needed;	/* if non-zero, it means the DEFERRED_SIGNAL_HANDLING_CHECK
+								 * macro needs to do some work.
+								 */

--- a/sr_port/handle_defered_signal.c
+++ b/sr_port/handle_defered_signal.c
@@ -1,0 +1,56 @@
+/****************************************************************
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
+ *	This source code contains the intellectual property	*
+ *	of its copyright holder(s), and is made available	*
+ *	under a license.  If you do not know the terms of	*
+ *	the license, please stop and do not read further.	*
+ *								*
+ ****************************************************************/
+
+#include "mdef.h"
+
+#include "have_crit.h"
+
+GBLREF	int		process_exiting;
+GBLREF	VSIG_ATOMIC_T	forced_exit;
+
+void	handle_deferred_signal(void)
+{
+	DEBUG_ONLY(char *dummy_rname;)
+
+	assert(DEFERRED_SIGNAL_HANDLING_TIMERS < DEFERRED_SIGNAL_HANDLING_CTRLZ);
+	assert(DEFERRED_SIGNAL_HANDLING_CTRLZ < DEFERRED_SIGNAL_HANDLING_EXIT);
+	assert(!INSIDE_THREADED_CODE(dummy_rname));		/* DEFERRED_SIGNAL_HANDLING_CHECK_TRIMMED ensures this */
+	assert(INTRPT_OK_TO_INTERRUPT == intrpt_ok_state);	/* DEFERRED_SIGNAL_HANDLING_CHECK_TRIMMED ensures this */
+	assert(deferred_signal_handling_needed);		/* DEFERRED_SIGNAL_HANDLING_CHECK_TRIMMED ensures this */
+	assert(!GET_DEFERRED_EXIT_CHECK_NEEDED || (1 == forced_exit));
+	assert(GET_DEFERRED_EXIT_CHECK_NEEDED || (1 != forced_exit));
+	if (process_exiting)
+		return;	/* Process is already exiting. Skip handling deferred events in that case. */
+	if (!OK_TO_INTERRUPT_TRIMMED)
+		return;	/* Not in a position to allow interrupt to happen. Defer interrupt handling to later. */
+	/* If forced_exit was set while in a deferred state, disregard any deferred timers or deferred Ctrl-Zs
+	 * and invoke deferred_signal_handler directly (note: this can cause us to terminate the process).
+	 */
+	if (forced_exit)
+	{
+		if (GET_DEFERRED_EXIT_CHECK_NEEDED)
+			deferred_signal_handler();
+	} else
+	{
+		if (GET_DEFERRED_TIMERS_CHECK_NEEDED)
+			check_for_deferred_timers();
+		if (GET_DEFERRED_CTRLZ_CHECK_NEEDED)
+		{	/* Clear the fact that we need deferred Ctrl-Z handling before doing "suspend"
+			 * as the latter can call some other function which has a deferred zone and
+			 * in turn invokes DEFERRED_SIGNAL_HANDLING_CHECK* macro at which point we do
+			 * not want to again do a nested suspend(SIGSTOP) processing.
+			 */
+			CLEAR_DEFERRED_CTRLZ_CHECK_NEEDED;
+			suspend(SIGSTOP);
+		}
+	}
+}

--- a/sr_port/have_crit.h
+++ b/sr_port/have_crit.h
@@ -18,7 +18,6 @@
 
 #include <signal.h>				/* needed for VSIG_ATOMIC_T */
 #include <deferred_signal_handler.h>
-#include "gtmsiginfo.h"				/* for DEFER_SUSPEND */
 
 /* states of CRIT passed as argument to have_crit() */
 #define CRIT_HAVE_ANY_REG	0x00000001
@@ -84,14 +83,42 @@ typedef enum
 } intrpt_state_t;
 
 GBLREF	intrpt_state_t	intrpt_ok_state;
-GBLREF	boolean_t	deferred_timers_check_needed;
+
+GBLREF	boolean_t	deferred_signal_handling_needed; /* a bitmask of the below DEFERRED_SIGNAL_HANDLING_NEEDED_* macros */
+
+#define	DEFERRED_SIGNAL_HANDLING_TIMERS	(1 << 0)	/* Bit in "deferred_signal_handling_neeed" global variable that
+							 * indicates whether deferred timer(s) needs to be handled
+							 * upon leaving deferred zone.
+							 */
+#define	DEFERRED_SIGNAL_HANDLING_CTRLZ	(1 << 1)	/* Bit in "deferred_signal_handling_neeed" global variable that
+							 * indicates whether deferred Ctrl-Z needs to be handled
+							 * upon leaving deferred zone.
+							 */
+#define	DEFERRED_SIGNAL_HANDLING_EXIT	(1 << 2)	/* Bit in "deferred_signal_handling_neeed" global variable that
+							 * indicates whether deferred signals (that will cause us to exit)
+							 * needs to be handled upon leaving deferred zone.
+							 */
+
+#define	GET_DEFERRED_TIMERS_CHECK_NEEDED	(deferred_signal_handling_needed & DEFERRED_SIGNAL_HANDLING_TIMERS)
+#define	SET_DEFERRED_TIMERS_CHECK_NEEDED	(deferred_signal_handling_needed |= (DEFERRED_SIGNAL_HANDLING_TIMERS))
+#define	CLEAR_DEFERRED_TIMERS_CHECK_NEEDED	(deferred_signal_handling_needed &= (~DEFERRED_SIGNAL_HANDLING_TIMERS))
+
+#define	GET_DEFERRED_CTRLZ_CHECK_NEEDED		(deferred_signal_handling_needed & DEFERRED_SIGNAL_HANDLING_CTRLZ)
+#define	SET_DEFERRED_CTRLZ_CHECK_NEEDED		(deferred_signal_handling_needed |= (DEFERRED_SIGNAL_HANDLING_CTRLZ))
+#define	CLEAR_DEFERRED_CTRLZ_CHECK_NEEDED	(deferred_signal_handling_needed &= (~DEFERRED_SIGNAL_HANDLING_CTRLZ))
+
+#define	GET_DEFERRED_EXIT_CHECK_NEEDED		(deferred_signal_handling_needed & DEFERRED_SIGNAL_HANDLING_EXIT)
+#define	SET_DEFERRED_EXIT_CHECK_NEEDED		(deferred_signal_handling_needed |= (DEFERRED_SIGNAL_HANDLING_EXIT))
+#define	CLEAR_DEFERRED_EXIT_CHECK_NEEDED	(deferred_signal_handling_needed &= (~DEFERRED_SIGNAL_HANDLING_EXIT))
+
+GBLREF	volatile int4	gtmMallocDepth;
 
 /* Macro to check if we are in a state that is ok to interrupt (or to do deferred signal handling). We do not want to interrupt if
  * the global variable intrpt_ok_state indicates it is not ok to interrupt, if we are in the midst of a malloc, if we are holding
  * crit, or if we are in the midst of a commit.
  */
-#define	OK_TO_INTERRUPT	((INTRPT_OK_TO_INTERRUPT == intrpt_ok_state) && (0 == gtmMallocDepth)			\
-				&& (0 == have_crit(CRIT_HAVE_ANY_REG | CRIT_IN_COMMIT)))
+#define	OK_TO_INTERRUPT	((INTRPT_OK_TO_INTERRUPT == intrpt_ok_state) && OK_TO_INTERRUPT_TRIMMED)
+#define	OK_TO_INTERRUPT_TRIMMED	((0 == gtmMallocDepth) && (0 == have_crit(CRIT_HAVE_ANY_REG | CRIT_IN_COMMIT)))
 
 /* Set the value of forced_exit to 1. This should indicate that we want a deferred signal handler to be invoked first upon leaving
  * the current deferred window. Since we do not want forced_exit state to ever regress, and there might be several signals delivered
@@ -106,6 +133,8 @@ GBLREF	boolean_t	deferred_timers_check_needed;
 	assert(!INSIDE_THREADED_CODE(rname));							\
 	assert((0 == forced_exit) || (1 == forced_exit));					\
 	forced_exit = 1;									\
+	/* Whenever "forced_exit" gets set to 1, set the corresponding deferred event too */	\
+	SET_DEFERRED_EXIT_CHECK_NEEDED;								\
 	SET_FORCED_THREAD_EXIT; /* Signal any running threads to stop */			\
 	SET_FORCED_MULTI_PROC_EXIT; /* Signal any parallel processes to stop */			\
 }
@@ -129,6 +158,8 @@ GBLREF	boolean_t	deferred_timers_check_needed;
 	assert(1 == forced_exit);								\
 	assert(forced_thread_exit);								\
 	forced_exit = 2;									\
+	/* Whenever "forced_exit" gets set to 2, clear the corresponding deferred event */	\
+	CLEAR_DEFERRED_EXIT_CHECK_NEEDED;							\
 }
 
 /* Macro to be used whenever we want to handle any signals that we deferred handling in the process.
@@ -138,43 +169,37 @@ GBLREF	boolean_t	deferred_timers_check_needed;
 {													\
 	char			*rname;									\
 													\
+	if (INSIDE_THREADED_CODE(rname))								\
+	{												\
+		PTHREAD_EXIT_IF_FORCED_EXIT;								\
+	} else if (INTRPT_OK_TO_INTERRUPT == intrpt_ok_state)						\
+		DEFERRED_SIGNAL_HANDLING_CHECK_TRIMMED;							\
+}
+
+/* This is a trimmed down version of the DEFERRED_SIGNAL_HANDLING_CHECK macro which is called
+ * when the following conditions are true.
+ *	a) multi_thread_in_use is FALSE
+ *	b) intrpt_ok_state == INTRPT_OK_TO_INTERRUPT
+ * This lets us call the trimmed down macro directly from the ENABLE_INTERRUPTS macro
+ * (which is used in a lot of places e.g. from the REVERT macro).
+ */
+#define	DEFERRED_SIGNAL_HANDLING_CHECK_TRIMMED								\
+{													\
+	DEBUG_ONLY(char		*rname;)								\
+													\
 	GBLREF	int		process_exiting;							\
 	GBLREF	VSIG_ATOMIC_T	forced_exit;								\
-	GBLREF	volatile int4	gtmMallocDepth;								\
-	GBLREF	volatile int	suspend_status;								\
 													\
 	/* The forced_exit state of 2 indicates that the exit is already in progress, so we do not	\
 	 * need to process any deferred events. Note if threads are running, check if forced_exit is	\
 	 * non-zero and if so exit the thread (using pthread_exit) otherwise skip deferred event	\
 	 * processing. A similar check will happen once threads stop running.				\
 	 */												\
-	if (INSIDE_THREADED_CODE(rname))								\
-	{												\
-		PTHREAD_EXIT_IF_FORCED_EXIT;								\
-	} else if (2 > forced_exit)									\
-	{	/* If forced_exit was set while in a deferred state, disregard any deferred timers and	\
-		 * invoke deferred_signal_handler directly.						\
-		 */											\
-		if (forced_exit)									\
-		{											\
-			if (!process_exiting && OK_TO_INTERRUPT)					\
-				deferred_signal_handler();						\
-		} else if (deferred_timers_check_needed)						\
-		{											\
-			if (!process_exiting && OK_TO_INTERRUPT)					\
-				check_for_deferred_timers();						\
-		}											\
-		/* Check if a Ctrl-Z signal handling was deferred and if it is safe to do so now */	\
-		if ((DEFER_SUSPEND == suspend_status) && OK_TO_INTERRUPT)				\
-		{	/* Reset the global "suspend_status" before doing the "suspend" call as the	\
-			 * latter can call some other function which has a deferred zone and in turn	\
-			 * invokes DEFERRED_SIGNAL_HANDLING_CHECK at which point we do not want to	\
-			 * again do a nested suspend(SIGSTOP) processing.				\
-			 */										\
-			suspend_status = NO_SUSPEND;							\
-			suspend(SIGSTOP);								\
-		}											\
-	}												\
+	assert(!INSIDE_THREADED_CODE(rname));								\
+	assert(!GET_DEFERRED_EXIT_CHECK_NEEDED || (1 == forced_exit));					\
+	assert(GET_DEFERRED_EXIT_CHECK_NEEDED || (1 != forced_exit));					\
+	if (deferred_signal_handling_needed)								\
+		handle_deferred_signal();								\
 }
 
 GBLREF	boolean_t	multi_thread_in_use;		/* TRUE => threads are in use. FALSE => not in use */
@@ -223,15 +248,16 @@ GBLREF	boolean_t	multi_thread_in_use;		/* TRUE => threads are in use. FALSE => n
 }
 
 /* Restore deferrable interrupts back to the state it was at time of corresponding DEFER_INTERRUPTS call */
-#define ENABLE_INTERRUPTS(OLDSTATE, NEWSTATE)									\
-{														\
-	if (!multi_thread_in_use)										\
-	{													\
-		assert(OLDSTATE == intrpt_ok_state);								\
-		intrpt_ok_state = NEWSTATE;									\
-		if (INTRPT_OK_TO_INTERRUPT == intrpt_ok_state)							\
-			DEFERRED_SIGNAL_HANDLING_CHECK;	/* check if signals were deferred in deferred zone */	\
-	}													\
+#define ENABLE_INTERRUPTS(OLDSTATE, NEWSTATE)							\
+{												\
+	if (!multi_thread_in_use)								\
+	{											\
+		assert(OLDSTATE == intrpt_ok_state);						\
+		intrpt_ok_state = NEWSTATE;							\
+		if (INTRPT_OK_TO_INTERRUPT == intrpt_ok_state)					\
+			DEFERRED_SIGNAL_HANDLING_CHECK_TRIMMED;					\
+				/* check if signals were deferred in deferred zone */		\
+	}											\
 }
 
 #define	OK_TO_SEND_MSG	((INTRPT_IN_X_TIME_FUNCTION != intrpt_ok_state) 				\
@@ -239,6 +265,7 @@ GBLREF	boolean_t	multi_thread_in_use;		/* TRUE => threads are in use. FALSE => n
 			&& (INTRPT_IN_FUNC_WITH_MALLOC != intrpt_ok_state)				\
 			&& (INTRPT_IN_FORK_OR_SYSTEM != intrpt_ok_state))
 
-uint4 have_crit(uint4 crit_state);
+uint4	have_crit(uint4 crit_state);
+void	handle_deferred_signal(void);
 
 #endif /* HAVE_CRIT_H_INCLUDED */

--- a/sr_port/t_end.c
+++ b/sr_port/t_end.c
@@ -1771,7 +1771,6 @@ skip_cr_array:
 	assert(!csa->now_crit || csa->hold_onto_crit);
 	assert(cdb_sc_normal == status);
 	REVERT;	/* no need for t_ch to be invoked if any errors occur after this point */
-	DEFERRED_SIGNAL_HANDLING_CHECK; /* now that crits are released, check if deferred signal/exit handling needs to be done */
 	assert(update_trans);
 	if (REPL_ALLOWED(csa) && IS_DSE_IMAGE)
 	{

--- a/sr_port/tp_tend.c
+++ b/sr_port/tp_tend.c
@@ -1882,7 +1882,6 @@ failed:
 	}
 skip_failed:
 	REVERT;
-	DEFERRED_SIGNAL_HANDLING_CHECK; /* now that crits are released, check if deferred signal/exit handling needs to be done */
 	if (cdb_sc_normal == status)
 	{
 		if (save_jnlpool != jnlpool)

--- a/sr_unix/continue_handler.c
+++ b/sr_unix/continue_handler.c
@@ -28,7 +28,7 @@
 #include "continue_handler.h"
 #include "gtmsecshr.h"
 
-GBLREF volatile int	suspend_status;
+GBLREF volatile int	is_suspended;
 GBLREF io_pair		io_std_device;
 GBLREF uint4		process_id;
 
@@ -47,21 +47,16 @@ void continue_handler(int sig, siginfo_t *info, void *context)
 	DEBUG_ONLY((TREF(continue_proc_cnt))++);
  	assert(SIGCONT == sig);
 	extract_signal_info(sig, info, context, &sig_info);
-	switch(suspend_status)
-	{
-		case NOW_SUSPEND:
-			/* Don't bother checking if user info is available. If info isn't available,
-			 * the value zero will be printed for pid and uid. Note that the following
-			 * message was previously put out even when the process was not suspended but
-			 * with the changes in spin locks that send continue messages "just in case",
-			 * I thought it better to restrict this message to when the process was actually
-			 * suspended and being continued. SE 7/01
-			 */
-			send_msg(VARLSTCNT(4) ERR_REQ2RESUME, 2, sig_info.send_pid, sig_info.send_uid);
-			/* Fall through */
-		case DEFER_SUSPEND:
-			/* If suspend was deferred, this continue/resume overrides/cancels it */
-			suspend_status = NO_SUSPEND;
-			break;
+	if (is_suspended)
+	{	/* Don't bother checking if user info is available. If info isn't available,
+		 * the value zero will be printed for pid and uid. Note that the following
+		 * message was previously put out even when the process was not suspended but
+		 * with the changes in spin locks that send continue messages "just in case",
+		 * I thought it better to restrict this message to when the process was actually
+		 * suspended and being continued. SE 7/01
+		 */
+		send_msg(VARLSTCNT(4) ERR_REQ2RESUME, 2, sig_info.send_pid, sig_info.send_uid);
 	}
+	is_suspended = FALSE;			/* Process is no longer suspended */
+	CLEAR_DEFERRED_CTRLZ_CHECK_NEEDED;	/* Clear any pending deferred Ctrl-Z handling too */
 }

--- a/sr_unix/gtmsiginfo.h
+++ b/sr_unix/gtmsiginfo.h
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2010 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2010 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -46,10 +49,6 @@ typedef	ucontext_t		gtm_sigcontext_t;
 #endif
 
 void extract_signal_info(int sig, siginfo_t *info, gtm_sigcontext_t *context, gtmsiginfo_t *gtmsi);
-
-#define NO_SUSPEND		0	/* Suspend not pending */
-#define DEFER_SUSPEND		1	/* Suspend deferred */
-#define NOW_SUSPEND		2	/* Suspend now; will indicate that we "suspended" ourselves when woken up */
 
 /* States of exit_state
  *

--- a/sr_unix/rel_crit.c
+++ b/sr_unix/rel_crit.c
@@ -36,9 +36,7 @@
 GBLREF	short 			crash_count;
 GBLREF	volatile int4		crit_count;
 GBLREF	uint4 			process_id;
-GBLREF	volatile int		suspend_status;
 GBLREF	node_local_ptr_t	locknl;
-GBLREF	volatile int4           gtmMallocDepth;         /* Recursion indicator */
 GBLREF	jnl_gbls_t		jgbl;
 
 error_def(ERR_CRITRESET);

--- a/sr_unix/rel_lock.c
+++ b/sr_unix/rel_lock.c
@@ -34,9 +34,7 @@
 
 GBLREF	volatile int4		crit_count;
 GBLREF	uint4 			process_id;
-GBLREF	volatile int		suspend_status;
 GBLREF	node_local_ptr_t	locknl;
-GBLREF	volatile int4           gtmMallocDepth;         /* Recursion indicator */
 GBLREF	jnl_gbls_t		jgbl;
 
 error_def(ERR_CRITRESET);

--- a/sr_unix/suspend.c
+++ b/sr_unix/suspend.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2018 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -21,7 +24,7 @@
 #include "send_msg.h"
 #include "setterm.h"
 
-GBLREF volatile int 	suspend_status;
+GBLREF volatile int 	is_suspended;	/* TRUE if this process is currently suspended */
 GBLREF io_pair		io_std_device;
 GBLREF uint4		process_id;
 GBLREF uint4 		sig_count;
@@ -34,7 +37,7 @@ void suspend(int sig)
 	int	status;
 
 	send_msg_csa(CSA_ARG(NULL) VARLSTCNT(3) ERR_SUSPENDING, 1, sig);
-	suspend_status = NOW_SUSPEND;
+	is_suspended = TRUE;
 	/* Dont call flush_pio() if the received signal is SIGTTOU OR if the received signal is SIGTTIN
 	 * and the $P.out is terminal. Arrival of SIGTTIN and SIGTTOU indicates that current process is
 	 * in the background. Hence it does not make sense to do flush_pio() $P.out is terminal.

--- a/sr_unix/suspsigs_handler.c
+++ b/sr_unix/suspsigs_handler.c
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001, 2012 Fidelity Information Services, Inc	*
+ * Copyright 2001, 2012 Fidelity Information Services, Inc	*
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -22,7 +25,6 @@
 
 #define MAXINOUT	16
 
-GBLREF	volatile int		suspend_status;
 GBLREF	uint4			process_id;
 GBLREF	volatile int4		exit_state;
 GBLREF	volatile int4		gtmMallocDepth; 	/* Recursion indicator */
@@ -43,7 +45,7 @@ void suspsigs_handler(int sig, siginfo_t* info, void *context)
 				if ((EXIT_NOTPENDING < exit_state) || !OK_TO_INTERRUPT)
 				{	/* Let the process run in the foreground till it finishes the terminal I/O */
 					if (EXIT_NOTPENDING == exit_state)
-						suspend_status = DEFER_SUSPEND;
+						SET_DEFERRED_CTRLZ_CHECK_NEEDED;
 					status = kill(process_id, SIGCONT);
 					assert(0 == status);
 					/*
@@ -77,7 +79,7 @@ void suspsigs_handler(int sig, siginfo_t* info, void *context)
 				{
 					if (!OK_TO_INTERRUPT)
 					{
-						suspend_status = DEFER_SUSPEND;
+						SET_DEFERRED_CTRLZ_CHECK_NEEDED;
 						break;
 					}
 					suspend(sig);


### PR DESCRIPTION
As part of a prior #215 commit, the DEFERRED_SIGNAL_HANDLING_CHECK macro was enhanced
to check for Ctrl-Z deferral. Turns out that change caused libyottadb.so size to bloat
from 5.00Mb (in r1.20) to 5.25Mb. This is because this macro is used in heavyweight
macros like REVERT which meant all the code inside this macro gets duplicated across
various parts of the compiled .o files thereby bloating the size of libyottadb.so (which
is just an aggregate of all the individual .o files).

To fix this size bloat, the macro was made minimalistic so it does a simple if check of
a global variable and if that is non-zero, in turn invoke a function that does most of
the code that was previously included in this macro. Thereby we centralize the code in
one place instead of inlining it everywhere the macro is used.

But we also do not want to slow down every macro invocation in the common case (which
is that we do not have any signals deferred). This meant that we cannot fold all the
logic in the macro into the function (as a function call is expensive and we don't want
to do it in every invocation of this macro).

The macro did 3 checks of deferred events
	a) forced_exit
	b) timers
	c) ctrl-z

As part of this commit, all the different checks now update a new global variable
"deferred_signal_handling_needed". It is a bitmask that has one bit set for each type
of deferred event (a, b or c above). So the macro can just do a check of this global
variable and if it is non-zero, invoke a new function "handle_deferred_signal()".

To achieve that, the following was done to the above 3 deferred event scenarios.

a) forced_exit was a multi-state variable so it was not easily replaced by the new bit.
   Therefore "deferred_signal_handling_needed & DEFERRED_SIGNAL_HANDLING_EXIT" was
   set to 1 if ever forced_exit was set to 1 and cleared if forced_exit was 0 or 2.
   And the two were maintained in sync.

b) deferred_timers_check_needed was a boolean variable so it was easily replaced by
   the new bit "deferred_signal_handling_needed & DEFERRED_SIGNAL_HANDLING_TIMERS".

c) suspend_status was a tri-state variable so it was not easily replaced by
   the new bit. Instead it was split into two new variables. One is the new bit
   "deferred_signal_handling_needed & DEFERRED_SIGNAL_HANDLING_CTRLZ" which indicates
   whether a ctrlz event got deferred or not. Another is a new global "is_suspended"
   which is TRUE if the process is currently suspended. This took case of the NOW_SUSPEND
   scenario from before.

With the above changes, the size of libyottadb.so came down from 5.25Mb down to 4.68Mb
which is better than even the 5.00Mb size in r1.20.

While at this, a use of the DEFERRED_SIGNAL_HANDLING_CHECK macro in t_end.c and tp_tend.c
is now removed since it occurs right after a REVERT which has the same check anyways
(REVERT -> ENABLE_INTERRUPTS -> DEFERRED_SIGNAL_HANDLING_CHECK_TRIMMED).