### PR TITLE
[#215] Address test failure and review comments

### DIFF
--- a/sr_port/dbcertify.h
+++ b/sr_port/dbcertify.h
@@ -304,7 +304,7 @@ void dbcertify_certify_phase(void);
 void dbcertify_dbfilop(phase_static_area *psa);
 #include <signal.h>
 void dbcertify_signal_handler(int sig, siginfo_t *info, void *context);
-void dbcertify_deferred_signal_handler(void);
+void dbcertify_deferred_exit_handler(void);
 /* Routines in dbcertify_funcs.c */
 void dbc_gen_temp_file_names(phase_static_area *psa);
 void dbc_open_command_file(phase_static_area *psa);

--- a/sr_port/dbcertify_certify_phase.c
+++ b/sr_port/dbcertify_certify_phase.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2005-2016 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -1464,7 +1467,7 @@ boolean_t dbc_split_blk(phase_static_area *psa, block_id blk_num, enum gdsblk_ty
 		psa->dbc_critical = FALSE;
 		if (forced_exit)
 		{	/* Our exit was deferred until we cleared the critical section area */
-			UNIX_ONLY(dbcertify_deferred_signal_handler());
+			UNIX_ONLY(dbcertify_deferred_exit_handler());
 			VMS_ONLY(sys$exit(exi_condition));
 		}
 		/* Update the transaction number in the fileheader for the next transaction */

--- a/sr_port/eintr_wrappers.h
+++ b/sr_port/eintr_wrappers.h
@@ -32,7 +32,7 @@
 #include "io.h"
 #include "gtm_stdio.h"
 #include "wcs_sleep.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "wbox_test_init.h"
 #endif
 

--- a/sr_port/gbldefs.c
+++ b/sr_port/gbldefs.c
@@ -1228,6 +1228,6 @@ GBLDEF	int4		tstart_gtmci_nested_level;	/* TREF(gtmci_nested_level) at the time 
 							 * This should be used only if dollar_tlevel is non-zero as it is not
 							 * otherwise maintained.
 							 */
-GBLDEF	boolean_t	deferred_signal_handling_needed;	/* if non-zero, it means the DEFERRED_SIGNAL_HANDLING_CHECK
+GBLDEF	uint4		deferred_signal_handling_needed;	/* if non-zero, it means the DEFERRED_SIGNAL_HANDLING_CHECK
 								 * macro needs to do some work.
 								 */

--- a/sr_port/gtm_malloc_src.h
+++ b/sr_port/gtm_malloc_src.h
@@ -75,7 +75,7 @@
 #include "have_crit.h"
 #include "gtm_env_init.h"
 #include "gtmio.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 
 /* This routine is compiled twice, once as debug and once as pro and put into the same pro build. The alternative
  * memory manager is selected with the debug flags (any non-zero ydb_dbglvl setting invokes debug memory manager in

--- a/sr_port/have_crit.h
+++ b/sr_port/have_crit.h
@@ -17,7 +17,7 @@
 #define HAVE_CRIT_H_INCLUDED
 
 #include <signal.h>				/* needed for VSIG_ATOMIC_T */
-#include <deferred_signal_handler.h>
+#include <deferred_exit_handler.h>
 
 /* states of CRIT passed as argument to have_crit() */
 #define CRIT_HAVE_ANY_REG	0x00000001
@@ -84,7 +84,7 @@ typedef enum
 
 GBLREF	intrpt_state_t	intrpt_ok_state;
 
-GBLREF	boolean_t	deferred_signal_handling_needed; /* a bitmask of the below DEFERRED_SIGNAL_HANDLING_NEEDED_* macros */
+GBLREF	uint4		deferred_signal_handling_needed; /* a bitmask of the below DEFERRED_SIGNAL_HANDLING_NEEDED_* macros */
 
 #define	DEFERRED_SIGNAL_HANDLING_TIMERS	(1 << 0)	/* Bit in "deferred_signal_handling_neeed" global variable that
 							 * indicates whether deferred timer(s) needs to be handled
@@ -199,7 +199,7 @@ GBLREF	volatile int4	gtmMallocDepth;
 	assert(!GET_DEFERRED_EXIT_CHECK_NEEDED || (1 == forced_exit));					\
 	assert(GET_DEFERRED_EXIT_CHECK_NEEDED || (1 != forced_exit));					\
 	if (deferred_signal_handling_needed)								\
-		handle_deferred_signal();								\
+		deferred_signal_handler();								\
 }
 
 GBLREF	boolean_t	multi_thread_in_use;		/* TRUE => threads are in use. FALSE => not in use */
@@ -266,6 +266,6 @@ GBLREF	boolean_t	multi_thread_in_use;		/* TRUE => threads are in use. FALSE => n
 			&& (INTRPT_IN_FORK_OR_SYSTEM != intrpt_ok_state))
 
 uint4	have_crit(uint4 crit_state);
-void	handle_deferred_signal(void);
+void	deferred_signal_handler(void);
 
 #endif /* HAVE_CRIT_H_INCLUDED */

--- a/sr_port/mur_close_files.c
+++ b/sr_port/mur_close_files.c
@@ -223,7 +223,7 @@ boolean_t mur_close_files(void)
 		assert(!rctl->db_updated || murgbl.clean_exit || !jgbl.onlnrlbk);
 		reg = rctl->gd;
 		/* reg could be NULL at this point in some rare cases (e.g. if we come to mur_close_files through
-		 * deferred_signal_handler as part of call_on_signal invocation and run down this region but encounter
+		 * deferred_exit_handler as part of call_on_signal invocation and run down this region but encounter
 		 * an error while running down another region, we could re-enter mur_close_files as part of exit handling.
 		 * In this case, since this region has already been rundown, skip running this down.
 		 */

--- a/sr_port/mur_open_files.c
+++ b/sr_port/mur_open_files.c
@@ -43,7 +43,7 @@
 #include "ftok_sems.h"
 #include "repl_instance.h"
 #include "mu_rndwn_repl_instance.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "mu_rndwn_file.h"
 #include "read_db_files_from_gld.h"
 #include "mur_db_files_from_jnllist.h"

--- a/sr_port/op_hang.c
+++ b/sr_port/op_hang.c
@@ -35,7 +35,7 @@
 # include "wcs_sleep.h"
 # include "wbox_test_init.h"
 # include "gtmio.h"
-# include "deferred_signal_handler.h"
+# include "deferred_exit_handler.h"
 # include "util.h"
 #endif
 

--- a/sr_port/secshr_db_clnup.c
+++ b/sr_port/secshr_db_clnup.c
@@ -224,7 +224,7 @@ void secshr_db_clnup(enum secshr_db_state secshr_state)
 				 * a "gds_rundown" of all open regions) BEFORE "secshr_db_clnup" gets called. In that case,
 				 * even if "si" and "csa" are accessible, db shared memory is not and so we should not
 				 * attempt to finish any commits that might seem unfinished in case this process got a SIG-15
-				 * and handled it as part of "deferred_signal_handler" in "t_end"/"tp_tend".
+				 * and handled it as part of "deferred_exit_handler" in "t_end"/"tp_tend".
 				 */
 				continue;
 			}
@@ -553,8 +553,8 @@ void secshr_db_clnup(enum secshr_db_state secshr_state)
 			}
 			jnlpool = save_jnlpool;
 		}
-		/* It is possible we are exiting while in the middle of a transaction (e.g. called through "deferred_signal_handler"
-		 * in the DEFERRED_SIGNAL_HANDLING_CHECK macro). Since exit handling code can start new non-TP transactions
+		/* It is possible we are exiting while in the middle of a transaction (e.g. called through "deferred_exit_handler"
+		 * in the DEFERRED_SIGNAL_HANDLING_CHECK* macros). Since exit handling code can start new non-TP transactions
 		 * (e.g. for statsdb rundown you need to kill ^%YGS node, for recording mprof stats you need to set a global node)
 		 * clean up the effects of any in-progress transaction before the "t_begin" call happens.
 		 */

--- a/sr_port/t_end.c
+++ b/sr_port/t_end.c
@@ -53,7 +53,7 @@
 #include "anticipatory_freeze.h"
 
 #include "gtmrecv.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "repl_instance.h"
 #include "format_targ_key.h"
 

--- a/sr_port/tp_tend.c
+++ b/sr_port/tp_tend.c
@@ -77,7 +77,7 @@
 #endif
 
 #include "gtmrecv.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "repl_instance.h"
 #include "shmpool.h"
 #include "db_snapshot.h"

--- a/sr_port/tp_unwind.c
+++ b/sr_port/tp_unwind.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -45,7 +45,7 @@
 #include "tp.h"
 #include "tp_restart.h"
 #ifdef UNIX
-# include "deferred_signal_handler.h"
+# include "deferred_exit_handler.h"
 #endif
 #ifdef GTM_TRIGGER
 # include "gv_trigger.h"

--- a/sr_port_cm/gtcmtr_terminate.c
+++ b/sr_port_cm/gtcmtr_terminate.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2015 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -28,7 +28,7 @@
 #include "gtcmtr_protos.h"
 #include "have_crit.h"
 #ifdef UNIX
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #endif
 
 GBLREF connection_struct *curr_entry;

--- a/sr_unix/dbcertify_deferred_exit_handler.c
+++ b/sr_unix/dbcertify_deferred_exit_handler.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2005-2016 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -10,9 +13,9 @@
  *								*
  ****************************************************************/
 
-/* Perform necessary functions for signal handling that was deferred.
-   Based on deferred_signal_handler() but without references to have_crit()
-   that pull in half of the GT.M world.
+/* Perform necessary functions for exit signal handling that were deferred.
+   Based on deferred_exit_handler() but without references to have_crit()
+   that pull in a lot of other helper modules/functions.
 */
 #include "mdef.h"
 
@@ -46,7 +49,7 @@ GBLREF	boolean_t		exit_handler_active;
 
 LITREF	gtmImageName		gtmImageNames[];
 
-void dbcertify_deferred_signal_handler(void)
+void dbcertify_deferred_exit_handler(void)
 {
 	/* To avoid nested calls to this routine, we advance the status of forced_exit. */
 	SET_FORCED_EXIT_STATE_ALREADY_EXITING;

--- a/sr_unix/deferred_exit_handler.c
+++ b/sr_unix/deferred_exit_handler.c
@@ -25,7 +25,7 @@
 #include "send_msg.h"
 #include "gtmio.h"
 #include "have_crit.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "gtmmsg.h"
 #include "forced_exit_err_display.h"
 #ifdef DEBUG
@@ -55,7 +55,7 @@ error_def(ERR_KILLBYSIGSINFO2);
 error_def(ERR_KILLBYSIGSINFO3);
 error_def(ERR_KILLBYSIGUINFO);
 
-void deferred_signal_handler(void)
+void deferred_exit_handler(void)
 {
 	void		(*signal_routine)();
 	char		*rname;

--- a/sr_unix/deferred_exit_handler.h
+++ b/sr_unix/deferred_exit_handler.h
@@ -1,6 +1,9 @@
 /****************************************************************
  *								*
- *	Copyright 2001 Sanchez Computer Associates, Inc.	*
+ * Copyright 2001 Sanchez Computer Associates, Inc.		*
+ *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
@@ -9,9 +12,9 @@
  *								*
  ****************************************************************/
 
-#ifndef DEFERRED_SIGNAL_HANDLER_INCLUDED
-#define DEFERRED_SIGNAL_HANDLER_INCLUDED
+#ifndef DEFERRED_EXIT_HANDLER_INCLUDED
+#define DEFERRED_EXIT_HANDLER_INCLUDED
 
-void deferred_signal_handler(void);
+void deferred_exit_handler(void);
 
-#endif /* DEFERRED_SIGNAL_HANDLER_INCLUDED */
+#endif /* DEFERRED_EXIT_HANDLER_INCLUDED */

--- a/sr_unix/grab_crit.c
+++ b/sr_unix/grab_crit.c
@@ -27,7 +27,7 @@
 #include "send_msg.h"
 #include "mutex.h"
 #include "wcs_recover.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "caller_id.h"
 #include "is_proc_alive.h"
 #ifdef DEBUG

--- a/sr_unix/grab_crit_immediate.c
+++ b/sr_unix/grab_crit_immediate.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -23,7 +26,7 @@
 #include "filestruct.h"
 #include "send_msg.h"
 #include "mutex.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "caller_id.h"
 #include "is_proc_alive.h"
 #include "gtmimagename.h"

--- a/sr_unix/grab_lock.c
+++ b/sr_unix/grab_lock.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -21,7 +24,7 @@
 #include "gdsfhead.h"
 #include "filestruct.h"
 #include "mutex.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "caller_id.h"
 #include "is_proc_alive.h"
 #include "repl_msg.h"

--- a/sr_unix/gtm_multi_proc.c
+++ b/sr_unix/gtm_multi_proc.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2015-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  *	This source code contains the intellectual property	*
@@ -218,7 +218,7 @@ int	gtm_multi_proc(gtm_multi_proc_fnptr_t fnptr, int ntasks, int max_procs,
 			{	/* The child process should operate as a regular process so re-enable interrupts.
 				 * But before that, set "process_id" to a value different from the parent
 				 * as the ENABLE_INTERRUPTS macro could end up calling
-				 * deferred_signal_handler -> forced_exit_err_display -> gtm_putmsg_csa -> grab_latch
+				 * deferred_exit_handler -> forced_exit_err_display -> gtm_putmsg_csa -> grab_latch
 				 * and grab_latch would fail an assert otherwise.
 				 */
 				getjobnum();    /* set "process_id" to a value different from parent */

--- a/sr_unix/gtmcrypt.h
+++ b/sr_unix/gtmcrypt.h
@@ -19,7 +19,7 @@
 #include "gtmxc_types.h"
 #include "gtmimagename.h"
 #include "have_crit.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "wbox_test_init.h"
 #include "gtmmsg.h"
 #include "error.h"					/* for MAKE_MSG_WARNING macro */

--- a/sr_unix/gtmrecv_process.c
+++ b/sr_unix/gtmrecv_process.c
@@ -69,7 +69,7 @@
 #include "jnl_typedef.h"
 #include "memcoherency.h"
 #include "have_crit.h"			/* needed for ZLIB_UNCOMPRESS */
-#include "deferred_signal_handler.h"	/* needed for ZLIB_UNCOMPRESS */
+#include "deferred_exit_handler.h"	/* needed for ZLIB_UNCOMPRESS */
 #include "gtm_zlib.h"
 #include "wbox_test_init.h"
 #ifdef GTM_TRIGGER

--- a/sr_unix/gtmsource_process.c
+++ b/sr_unix/gtmsource_process.c
@@ -63,7 +63,7 @@
 #include "gtmmsg.h"
 #include "repl_sem.h"
 #include "have_crit.h"			/* needed for ZLIB_COMPRESS */
-#include "deferred_signal_handler.h"	/* needed for ZLIB_COMPRESS */
+#include "deferred_exit_handler.h"	/* needed for ZLIB_COMPRESS */
 #include "gtm_zlib.h"
 #include "repl_sort_tr_buff.h"
 #include "replgbl.h"

--- a/sr_unix/gtmsource_process_ops.c
+++ b/sr_unix/gtmsource_process_ops.c
@@ -66,7 +66,7 @@
 #include "gtmmsg.h"
 #include "wbox_test_init.h"
 #include "have_crit.h"			/* needed for ZLIB_COMPRESS */
-#include "deferred_signal_handler.h"	/* needed for ZLIB_COMPRESS */
+#include "deferred_exit_handler.h"	/* needed for ZLIB_COMPRESS */
 #include "gtm_zlib.h"
 #include "replgbl.h"
 #include "repl_inst_dump.h"		/* for "repl_dump_histinfo" prototype */

--- a/sr_unix/rel_crit.c
+++ b/sr_unix/rel_crit.c
@@ -27,7 +27,7 @@
 #include "filestruct.h"
 #include "gtmsiginfo.h"
 #include "mutex.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "have_crit.h"
 #include "caller_id.h"
 #include "jnl.h"

--- a/sr_unix/rel_lock.c
+++ b/sr_unix/rel_lock.c
@@ -27,7 +27,7 @@
 #include "filestruct.h"
 #include "gtmsiginfo.h"
 #include "mutex.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "have_crit.h"
 #include "caller_id.h"
 #include "jnl.h"

--- a/sr_unix/send_msg.c
+++ b/sr_unix/send_msg.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -97,7 +100,7 @@ void send_msg_va(void *csa, int arg_count, va_list var)
 	 * exception to this is if the nested call to send_msg is done by exit handling code in which case the
 	 * latest send_msg call prevails and it is ok since we will never return to the original send_msg call
 	 * again. The other exception is if enable interrupts in util_out_send_oper results in a new send_msg
-	 * in deferred_signal_handler.
+	 * in deferred_exit_handler.
 	 */
 	assert((0 == nesting_level) || ((2 > nesting_level) && timer_in_handler)
 		|| (EXIT_IMMED == exit_state) || (2 == forced_exit));

--- a/sr_unix/set_num_additional_processors.c
+++ b/sr_unix/set_num_additional_processors.c
@@ -40,7 +40,7 @@
 #include "gtm_stdio.h"
 #include "wcs_sleep.h"
 #include "wbox_test_init.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #endif
 
 GBLREF int	num_additional_processors;

--- a/sr_unix/wcs_wtstart.c
+++ b/sr_unix/wcs_wtstart.c
@@ -51,7 +51,7 @@
 #include "gtm_string.h"
 #include "have_crit.h"
 #include "gds_blk_downgrade.h"
-#include "deferred_signal_handler.h"
+#include "deferred_exit_handler.h"
 #include "memcoherency.h"
 #include "wbox_test_init.h"
 #include "wcs_clean_dbsync.h"


### PR DESCRIPTION
* An "assert(deferred_signal_handling_needed);" in sr_port/handle_deferred_signal.c was
  removed since it can cause test failures in some cases (timer pops etc.).

* sr_unix/deferred_signal_handler.c was renamed to sr_unix/deferred_exit_handler.c
  since this function is invoked when we need to handle deferred signals that initiate
  exit processing. Likewise, sr_unix/deferred_signal_handler.h was renamed to
  sr_unix/deferred_exit_handler.h.

* Similar to the previous bullet, sr_port/dbcertify_deferred_signal_handler.c was renamed
  to sr_port/dbcertify_deferred_exit_handler.c.

* sr_port/handle_defered_signal.c was renamed to sr_port/deferred_signal_handler.c since
  this routine handled deferred signals that do not terminate the process (distinction
  from the newly renamed deferred_exit_handler.c where the deferred signals do terminate
  the process). And the function handle_deferred_signal() (which had a slightly different
  name than the module handle_defered_signal.c) was renamed to deferred_signal_handler().

* The type of "deferred_signal_handling_needed" was changed from boolean_t to uint4.