### PR TITLE
Revert "Bump YottaDB release # from r122 to r123 now that r1.22 is released"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(lang ${languages})
 endforeach()
 
 # Defaults
-set(version r123)
+set(version r122)
 
 # If CMAKE_BUILD_TYPE is not defined make it a Release build
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)

--- a/sr_linux/release_name.h
+++ b/sr_linux/release_name.h
@@ -20,7 +20,7 @@
 
 #define GTM_VERSION		"V6.3"
 #define	GTM_ZVERSION		"V6.3-004"
-#define	YDB_ZYRELEASE		"r1.23"
+#define	YDB_ZYRELEASE		"r1.22"
 
 /* Note: YDB_RELEASE_STAMP is set as part of the cmake build process.
  * Example values are


### PR DESCRIPTION
This reverts commit 04c18105287b3cad2092ff8ebe591bf0ff98e665.
And is needed to rebuild r1.22 after a patch commit for #197