### PR TITLE
Bump LOCK_TRIES from 50 seconds to 200 seconds (4x) on 1-CPU systems to address occasional test failures

### DIFF
--- a/sr_port/relqueopi.c
+++ b/sr_port/relqueopi.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2001-2015 Fidelity National Information 	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
- * Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries.	*
+ * Copyright (c) 2017-2018 YottaDB LLC. and/or its subsidiaries.*
  * All rights reserved.						*
  *								*
  * Copyright (c) 2017 Stephen L Johnson. All rights reserved.	*
@@ -63,12 +63,13 @@ GBLREF	int		num_additional_processors;
 
 int insqhi2(que_ent_ptr_t new, que_head_ptr_t base)
 {
-	int	retries, spins, maxspins;
+	int	retries, spins, maxspins, maxtries;
 	uint4	stuck_cnt = 0;
 
 	++fast_lock_count;			/* Disable wcs_stale for duration */
 	maxspins = num_additional_processors ? MAX_LOCK_SPINS(LOCK_SPINS, num_additional_processors) : 1;
-	for (retries = LOCK_TRIES - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
+	maxtries = MAX_LOCK_TRIES(LOCK_TRIES_50sec);
+	for (retries = maxtries - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
 	{
 		for (spins = maxspins; 0 < spins; spins--)
 		{
@@ -109,12 +110,13 @@ int insqhi2(que_ent_ptr_t new, que_head_ptr_t base)
 
 int insqti2(que_ent_ptr_t new, que_head_ptr_t base)
 {
-	int	retries, spins, maxspins;
+	int	retries, spins, maxspins, maxtries;
 	uint4	stuck_cnt = 0;
 
 	++fast_lock_count;			/* Disable wcs_stale for duration */
 	maxspins = num_additional_processors ? MAX_LOCK_SPINS(LOCK_SPINS, num_additional_processors) : 1;
-	for (retries = LOCK_TRIES - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
+	maxtries = MAX_LOCK_TRIES(LOCK_TRIES_50sec);
+	for (retries = maxtries - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
 	{
 		for (spins = maxspins; 0 < spins; spins--)
 		{
@@ -155,13 +157,14 @@ int insqti2(que_ent_ptr_t new, que_head_ptr_t base)
 
 void_ptr_t remqhi1(que_head_ptr_t base)
 {
-	int		retries, spins, maxspins;
+	int		retries, spins, maxspins, maxtries;
 	que_ent_ptr_t	ret;
 	uint4		stuck_cnt = 0;
 
 	++fast_lock_count;			/* Disable wcs_stale for duration */
 	maxspins = num_additional_processors ? MAX_LOCK_SPINS(LOCK_SPINS, num_additional_processors) : 1;
-	for (retries = LOCK_TRIES - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
+	maxtries = MAX_LOCK_TRIES(LOCK_TRIES_50sec);
+	for (retries = maxtries - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
 	{
 		for (spins = maxspins; 0 < spins; spins--)
 		{
@@ -209,13 +212,14 @@ void_ptr_t remqhi1(que_head_ptr_t base)
 
 void_ptr_t remqti1(que_head_ptr_t base)
 {
-	int		retries, spins, maxspins;
+	int		retries, spins, maxspins, maxtries;
 	que_ent_ptr_t	ret;
 	uint4		stuck_cnt = 0;
 
 	++fast_lock_count;			/* Disable wcs_stale for duration */
 	maxspins = num_additional_processors ? MAX_LOCK_SPINS(LOCK_SPINS, num_additional_processors) : 1;
-	for (retries = LOCK_TRIES - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
+	maxtries = MAX_LOCK_TRIES(LOCK_TRIES_50sec);
+	for (retries = maxtries - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
 	{
 		for (spins = maxspins; 0 < spins; spins--)
 		{

--- a/sr_port/sleep_cnt.h
+++ b/sr_port/sleep_cnt.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -66,16 +69,21 @@
 
 /*  For use by spin locks, SLEEP is ms, total should be under a minute */
 #define LOCK_TRIES_PER_SEC	(4 * 1000)	/* In outer loop: 1 loop in 4 is sleep of 1ms */
-#define LOCK_TRIES		(50 * LOCK_TRIES_PER_SEC)	/* Approximately 50 seconds for non-IO locks */
-#define LOCK_SPINS		1024		/* Inner spin loop base */
-#define LOCK_SPINS_PER_4PROC	256		/* Additional lock spins for every 4 processors past first 8 */
-#define LOCK_SLEEP		1		/* Very short sleep before repoll lock */
-#define LOCK_SPIN_HARD_MASK	0x3		/* Used to cause 4 hard spins */
-#define LOCK_CASLATCH_CHKINTVL	16384		/* Check CASLatch for abandonment/wakeup interval. This interval
-						 * is currently ~4 seconds but checking for 16384 (power of 2) rather
-						 * than (4 * LOCK_TRIES_PER_SEC) allows a faster remainder using AND
-						 * so use that instead.
-						 */
+#define LOCK_TRIES_50sec	(50 * LOCK_TRIES_PER_SEC)	/* Approximately 50 seconds for non-IO locks */
+/* LOCK_TRIES_50sec in single-cpu systems gives a max timeout of 50 seconds. But in single-cpu systems, particularly
+ * on the ARMV6L (Raspberry Pi Zero) architecture, we have seen this timeout as not being enough in in-house testing.
+ * So bump the timeout to 4 times the 50 seconds in the hope that would be enough. Do this for all single-cpu systems.
+ */
+#define	MAX_LOCK_TRIES(X)	(num_additional_processors ? X : (X * 4))
+#define LOCK_SPINS		1024			/* Inner spin loop base */
+#define LOCK_SPINS_PER_4PROC	256			/* Additional lock spins for every 4 processors past first 8 */
+#define LOCK_SLEEP		1			/* Very short sleep before repoll lock */
+#define LOCK_SPIN_HARD_MASK	0x3			/* Used to cause 4 hard spins */
+#define LOCK_CASLATCH_CHKINTVL	16384			/* Check CASLatch for abandonment/wakeup interval. This interval
+							 * is currently ~4 seconds but checking for 16384 (power of 2) rather
+							 * than (4 * LOCK_TRIES_PER_SEC) allows a faster remainder using AND
+							 * so use that instead.
+							 */
 #define	LOCK_CASLATCH_CHKINTVL_USEC	16384 * 128	/* This is used in callers that sleep for 1 micro-sec every 4 iterations
 							 * (instead of the usual 1 millisecond). Here too we want the caslatch
 							 * check to be done every ~4 seconds. One might be tempted to make

--- a/sr_port/updhelper_reader.c
+++ b/sr_port/updhelper_reader.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2005-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -143,7 +146,7 @@ boolean_t updproc_preread(void)
 {
 	boolean_t		good_record, was_wrapped;
 	uint4			pre_read_offset;
-	int			rec_len, cnt, retries, spins, maxspins, key_len;
+	int			rec_len, cnt, retries, spins, maxspins, maxtries, key_len;
 	enum jnl_record_type	rectype;
 	mstr_len_t		val_len;
 	mname_entry		gvname;
@@ -174,6 +177,7 @@ boolean_t updproc_preread(void)
 
 	SETUP_THREADGBL_ACCESS;
 	maxspins = num_additional_processors ? MAX_LOCK_SPINS(LOCK_SPINS, num_additional_processors) : 1;
+	maxtries = MAX_LOCK_TRIES(LOCK_TRIES_50sec);
 	upd_proc_local = recvpool.upd_proc_local;
 	recvpool_ctl = recvpool.recvpool_ctl;
 	gtmrecv_local = recvpool.gtmrecv_local;
@@ -196,7 +200,7 @@ boolean_t updproc_preread(void)
 				pre_read_offset, upd_proc_local->read, recvpool_ctl->write);
 			return TRUE;
 		}
-		for (retries = LOCK_TRIES - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
+		for (retries = maxtries - 1; 0 < retries; retries--)	/* - 1 so do rel_quant 3 times first */
 		{	/* seems like this might be a legitimate spin lock - might could use some work to tighten it up */
 			for (spins = maxspins; 0 < spins; spins--)
 			{


### PR DESCRIPTION
We have seen assert failures in debug builds in in-house testing on 1-CPU systems
(Raspberry Pi Zero and Beagblebone Black) in various tests occasionally.

The assert that fails is always the following.

%YDB-F-ASSERT, Assert failed in /Distrib/YottaDB/V999_R120/sr_port/relqueopi.c line 205
								for expression (FALSE)

This is in the remqhi1() function when it has waited for 50 seconds to get the queue
header latch (GET_SWAPLOCK).

The 1-CPU systems that we have seen this failure on are slow boxes so this commit gives
such systems 4x the time (4 * 50 seconds) before signaling an assert failure.

In production builds, one would have gotten a DBCCERR error though we have not yet seen such
a failure in our in-house testing.

With the fix, the assert failure and DBCCERR error failures are expected to go away.