### PR TITLE
Bump PHASE2_COMMIT_WAIT from 1 minute to 4 minutes (4x) on 1-CPU systems to address occasional test failures

### DIFF
--- a/sr_port/sleep_cnt.h
+++ b/sr_port/sleep_cnt.h
@@ -18,6 +18,8 @@
 
 #include "min_max.h"
 
+GBLREF int	num_additional_processors;	/* needed by a few macros below */
+
 /* Note: GT.M code *MUST*NOT* make use of the sleep() function because use of the sleep() function	(BYPASSOK - sleep())
  * causes problems with GT.M's timers on some platforms. Specifically, the sleep() function
  * causes the SIGARLM handler to be silently deleted on Solaris systems (through Solaris 9 at least).
@@ -53,7 +55,11 @@
 #define MAX_WTSTART_FINI_SLEEPS	(4 * SLEEP_ONE_MIN * MAXSLPTIME)/* After this many sleeps (each 1 msec in duration)
 								 * without progress, request cache recovery.
 								 */
-#define	PHASE2_COMMIT_WAIT	SLEEP_ONE_MIN
+/* On the ARMV6L (Raspberry Pi Zero) architecture where there is just one CPU, we have seen the below timeout
+ * of 1 minute (for phase2 commit wait) as not enough in in-house testing. So bump the timeout to 4 times the 1 minute
+ * in the hope that would be enough. Do this for all single-cpu systems.
+ */
+#define	PHASE2_COMMIT_WAIT	(num_additional_processors ? SLEEP_ONE_MIN : (SLEEP_ONE_MIN * 4))
 
 #define	SLEEP_INSTFREEZEWAIT	100		/* 100-msec wait between re-checks of instance freeze status */
 #define	SLEEP_IORETRYWAIT	500		/* 500-msec wait between retries of the same write operation */


### PR DESCRIPTION
We have occasionally seen an assert failure in debug builds in in-house testing on the
Raspberry Pi Zero (a 1-CPU system).
```
%YDB-F-ASSERT, Assert failed in /Distrib/YottaDB/V998_R122/sr_port/wcs_phase2_commit_wait.c
	line 337 for expression (cnl->wc_blocked
				|| (WBTEST_CRASH_SHUTDOWN_EXPECTED == ydb_white_box_test_case_number))
```
The update helper reader process waited 1 minute for a specific cache-record in phase2 commit
to be freed up by the update process and timed out.

The 1-CPU system that we have seen this failure is a slow box so this commit gives
such systems 4x the time (4 minutes) before signaling an assert failure.

In production builds, this was a non-issue since the timeout would have returned FALSE from
wcs_phase2_commit_wait() which in turn would have triggered a wcs_recover() (cache recovery)
with no user-visible consequences.