### PR TITLE
[#264] Handle return value of 0 from read() i.e. EOF on pipe fd

### DIFF
--- a/sr_port/repl_filter.c
+++ b/sr_port/repl_filter.c
@@ -803,7 +803,7 @@ STATICFNDEF int repl_filter_recv_line(char *line, int *line_len, int max_line_le
 			do
 			{
 				r_len = read(repl_filter_srv_fd[READ_END], srv_read_end, buff_remaining);
-				if (0 < r_len)
+				if (0 <= r_len)
 					break;
 				save_errno = errno;
 				if ((ENOMEM != save_errno) && (EINTR != save_errno))


### PR DESCRIPTION
Not doing so could cause the source server to loop indefinitely in case the filter program
terminates prematurely.