### PR TITLE
Fix DBFILOPERR message text to say database file (instead of region) as it is the file name that is printed (not the region name)

### DIFF
--- a/sr_port/merrors.msg
+++ b/sr_port/merrors.msg
@@ -558,7 +558,7 @@ NOCCPPID	<Cannot find CCP process id>/error/fao=0!/ansi=0
 CCPJNLOPNERR	<Error opening journal file.  Database not opened.>/error/fao=0!/ansi=0
 LCKSGONE	<Locks selected for deletion removed>/success/fao=0!/ansi=0
 UNUSEDMSG560	<ZLKIDBADARG nixed in r1.20 because it is a VMS only error>/error/fao=0!/ansi=0
-DBFILOPERR	<Error doing database I/O to region !AD>/error/fao=2!/ansi=0
+DBFILOPERR	<Error doing database I/O to database file !AD>/error/fao=2!/ansi=0
 CCERDERR	<Error reading from database file !AD>/error/fao=2!/ansi=0
 CCEDBCL		<Database file !AD is clustered>/info/fao=2!/ansi=0
 CCEDBNTCL	<Database file !AD is not clustered>/info/fao=2!/ansi=0

--- a/sr_port/merrors_ctl.c
+++ b/sr_port/merrors_ctl.c
@@ -394,7 +394,7 @@ LITDEF	err_msg merrors[] = {
 	{ "CCPJNLOPNERR", "Error opening journal file.  Database not opened.", 0 },
 	{ "LCKSGONE", "Locks selected for deletion removed", 0 },
 	{ "UNUSEDMSG560", "ZLKIDBADARG nixed in r1.20 because it is a VMS only error", 0 },
-	{ "DBFILOPERR", "Error doing database I/O to region !AD", 2 },
+	{ "DBFILOPERR", "Error doing database I/O to database file !AD", 2 },
 	{ "CCERDERR", "Error reading from database file !AD", 2 },
 	{ "CCEDBCL", "Database file !AD is clustered", 2 },
 	{ "CCEDBNTCL", "Database file !AD is not clustered", 2 },


### PR DESCRIPTION
All current usages of DBFILOPERR error pass the database file name (not the region) so no
other change needed in the callers of DBFILOPERR.