### PR TITLE
[#275] Allow LISTENING sockets to be passed to other processes without hanging (through JOB command or LOCAL socket passing)

### DIFF
--- a/sr_port/iosocket_open.c
+++ b/sr_port/iosocket_open.c
@@ -433,7 +433,7 @@ short	iosocket_open(io_log_name *dev, mval *pp, int file_des, mval *mspace, int4
 				REVERT_GTMIO_CH(&ioptr->pair, ch_set);
 				return FALSE;
 			}
-			assert(listen_specified == socketptr->passive);
+			assert((listen_specified == socketptr->passive) || (!listen_specified && is_principal));
 			if (ioerror_specified)
 				socketptr->ioerror = ('T' == ioerror || 't' == ioerror);
 			socketptr->nodelay = nodelay_specified;		/* defaults to DELAY */


### PR DESCRIPTION
* sr_port/iosocket_create.c :
  In case the JOB command specifies an INPUT/OUTPUT/STDERR that is a socket handle,
  iosocket_create() would be invoked by the jobbed off process as part of io_init()
  when it detects that its principal device is a socket. This code was assuming
  that the socket is a CONNECTED socket when in fact it could be a LISTENING socket
  too (nothing in the code currently prevents a LISTENING socket from being passed
  around). But since the initialization in iosocket_create() happened as if the
  socket is a connected socket, a later iosocket_wait() call (when a WRITE /WAIT is
  done) will not do the right calls (a listening socket needs to do an accept() call).
  The fix for this is to set the socketptr->state to "socket_listening" instead of
  "socket_connected" based on what getsockopt() returns the socket type as. In addition
  socketptr->passive is set to TRUE in case it is a listening socket and FALSE otherwise.
  And some initialization of the remote side is skipped if the socket is listening (the
  remote side is relevant only after a connection has been established).

* sr_port/iosocket_open.c :
  Now that iosocket_create() can return with socketptr->passive set to TRUE (in case
  the principal device socket is LISTENING), even though LISTEN was not explicitly
  specified, an assert needed to be modified.

* sr_port/iosocket_close.c :
  iosocket_close_one() is invoked by both JOB command as well as the LOCAL socket passing
  code to close the passed socket. As part of this an UNLINK of the socket file was being
  done (in iosocket_close_range()). But this is not correct for a passed socket in the
  LISTENING state as that file is the means by which a connection can be established with
  a future client. So we now pass SOCKET_DELETE_FALSE to indicate no socket file deletion
  when iosocket_close_range() is called through iosocket_close_one(). Not doing so will
  cause hangs (on both client and server side) when the new process tries to use the passed
  LISTENING socket to connect. While at this module, it was noticed that pre-existing
  parameters "socket_delete" and "socket_specified" were not used so those were removed
  from the interface of iosocket_close_range().