### PR TITLE
Do not assert fail in case tcsetattr() call fails and a white-box case indicates terminal is killed

### DIFF
--- a/sr_port/wbox_test_init.h
+++ b/sr_port/wbox_test_init.h
@@ -88,7 +88,7 @@ typedef enum {
 						 *      assert in mur_process_intrpt_recov.c */
 	WBTEST_HOLD_ONTO_FTOKSEM_IN_DBINIT,	/* 49 : Sleep in db_init after getting hold of the ftok semaphore */
 	WBTEST_HOLD_ONTO_ACCSEM_IN_DBINIT,	/* 50 : Sleep in db_init after getting hold of the access control semaphore */
-	WBTEST_UNUSED51,			/* 51 : UNUSED - YDB#235 removed the only place to test this */
+	WBTEST_KILL_TERMINAL,			/* 51 : Terminal is killed so accept errors due to this */
 	WBTEST_SYSCONF_WRAPPER,			/* 52 : Will sleep in SYSCONF wrapper to let us verify that first two MUPIP STOPs
 						 *	are indeed deferred in the interrupt-deferred zone, but the third isn't */
         WBTEST_DEFERRED_TIMERS,			/* 53 : Will enter a long loop upon specific WRITE or MUPIP STOP command */

--- a/sr_unix/iott_use.c
+++ b/sr_unix/iott_use.c
@@ -117,7 +117,6 @@ void iott_use(io_desc *iod, mval *pp)
 		if (0 != status)
 		{
 			save_errno = errno;
-			ISSUE_NOPRINCIO_IF_NEEDED_TT(io_curr_device.out);
 			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCGETATTR, 1, tt_ptr->fildes, save_errno);
 		}
 		flush_input = FALSE;
@@ -454,7 +453,7 @@ void iott_use(io_desc *iod, mval *pp)
 		Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno);
 		if (0 != status)
 		{
-			assert(FALSE);
+			assert(WBTEST_KILL_TERMINAL == ydb_white_box_test_case_number);
 			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
 		}
 		if (tt == d_in->type)


### PR DESCRIPTION
This fixes an occasional v63003/gtm8787 subtest failure due to an assert failure at line 457 below.
```c
iott_use.c
  454  Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno);
  455  if (0 != status)
  456  {
  457          assert(FALSE);
  458          rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
  459  }
```
In the gtm8787 subtest, the terminal is killed so the error from Tcsetattr() (save_errno = 5/EIO)
is not unexpected. To work around the assert failure, check for a specific white-box case (the newly
introduced WBTEST_KILL_TERMINAL case) and if so skip the assert.

While modifying iott_use.c, noticed a ISSUE_NOPRINCIO_IF_NEEDED_TT usage in case tcgetattr() call on
the terminal fd fails. I don't see the need for this call to issue NOPRINCIO error. It is better for
the NOPRINCIO error to be issued if a write() to the terminal fails (taken care of in iott_write.c
and iott_flush.c). So removed this usage in iott_use.c. In this case, a TCGETATTR error would be issued
and that should be good enough. If ever an attempt is made to display this error message to the terminal
then a NOPRINCIO error would be issued which seems more appropriate to me.