### PR TITLE
[#282] Enhance source server to handle FILEDELFAIL and RENAMEFAIL error scenarios in a user-friendly fashion

### DIFF
--- a/sr_port/jnl.h
+++ b/sr_port/jnl.h
@@ -1847,7 +1847,7 @@ void	jnl_prc_vector(jnl_process_vector *pv);
 void	jnl_send_oper(jnl_private_control *jpc, uint4 status);
 uint4	cre_jnl_file(jnl_create_info *info);
 uint4 	cre_jnl_file_common(jnl_create_info *info, char *rename_fn, int rename_fn_len);
-void	cre_jnl_file_intrpt_rename(sgmnt_addrs *csa);
+uint4	cre_jnl_file_intrpt_rename(sgmnt_addrs *csa);
 void	jfh_from_jnl_info (jnl_create_info *info, jnl_file_header *header);
 uint4	jnl_ensure_open(gd_region *reg, sgmnt_addrs *csa);
 void	set_jnl_info(gd_region *reg, jnl_create_info *set_jnl_info);

--- a/sr_port/wbox_test_init.h
+++ b/sr_port/wbox_test_init.h
@@ -88,7 +88,7 @@ typedef enum {
 						 *      assert in mur_process_intrpt_recov.c */
 	WBTEST_HOLD_ONTO_FTOKSEM_IN_DBINIT,	/* 49 : Sleep in db_init after getting hold of the ftok semaphore */
 	WBTEST_HOLD_ONTO_ACCSEM_IN_DBINIT,	/* 50 : Sleep in db_init after getting hold of the access control semaphore */
-	WBTEST_KILL_TERMINAL,			/* 51 : Terminal is killed so accept errors due to this */
+	WBTEST_UNUSED51,			/* 51 : UNUSED - YDB#235 removed the only place to test this */
 	WBTEST_SYSCONF_WRAPPER,			/* 52 : Will sleep in SYSCONF wrapper to let us verify that first two MUPIP STOPs
 						 *	are indeed deferred in the interrupt-deferred zone, but the third isn't */
         WBTEST_DEFERRED_TIMERS,			/* 53 : Will enter a long loop upon specific WRITE or MUPIP STOP command */
@@ -186,11 +186,17 @@ typedef enum {
 	WBTEST_NO_REPLINSTMULTI_FAIL,		/* 137 : Unless specified tests should not fail with REPLMULTINSTUPDATE */
 	WBTEST_DOLLARDEVICE_BUFFER,		/* 138 : Force larger error messages for $device to exceed DD_BUFLEN */
 	WBTEST_LOWERED_JNLEPOCH,		/* 139 : Force larger error messages for $device to exceed DD_BUFLEN */
-	WBTEST_SIGTERM_IN_JOB_CHILD		/* 140 : Generate Sigterm  by killing ourselves before the child fork */
+	WBTEST_SIGTERM_IN_JOB_CHILD,		/* 140 : Generate Sigterm  by killing ourselves before the child fork */
 	/* Note 1: when adding new white box test cases, please make use of WBTEST_ENABLED and WBTEST_ASSIGN_ONLY (defined below)
 	 * whenever applicable
 	 * Note 2: when adding a new white box test case, see if an existing WBTEST_UNUSED* slot can be leveraged.
 	 */
+	/* Start section for YDB-only white-box test cases with a higher number so we do not interfere with
+	 * GT.M additions to the above list of cases.
+	 */
+	WBTEST_YDB_KILL_TERMINAL = 200,		/* 200 : Terminal is killed so accept errors due to this */
+	WBTEST_YDB_FILEDELFAIL,			/* 201 : Exercise FILEDELFAIL error codepath in "cre_jnl_file_intrpt_rename" */
+	WBTEST_YDB_RENAMEFAIL,			/* 202 : Exercise RENAMEFAIL error codepath in "cre_jnl_file_intrpt_rename" */
 } wbtest_code_t;
 
 #ifdef DEBUG

--- a/sr_unix/iott_use.c
+++ b/sr_unix/iott_use.c
@@ -453,7 +453,7 @@ void iott_use(io_desc *iod, mval *pp)
 		Tcsetattr(tt_ptr->fildes, TCSANOW, &t, status, save_errno);
 		if (0 != status)
 		{
-			assert(WBTEST_KILL_TERMINAL == ydb_white_box_test_case_number);
+			assert(WBTEST_YDB_KILL_TERMINAL == ydb_white_box_test_case_number);
 			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(4) ERR_TCSETATTR, 1, tt_ptr->fildes, save_errno);
 		}
 		if (tt == d_in->type)


### PR DESCRIPTION
See issue description at YottaDB/YottaDB#282 for background. The crux of the fix is to
sr_port/cre_jnl_file_intrpt_rename.c and sr_port/gtmsource_ctl_init.c. The function
cre_jnl_file_intrpt_rename() now returns a status (previously it was void) and its return
value is used to determine whether special action needs to be taken in case of the source server.

In order to test these error scenarios, two white-box cases were introduced. And to
avoid collision with GTM introduced wbox codes, the YottaDB white-box codes start at 200
which gives a gap of 60 codes that should be ample enough a gap for a few years at least.