### PR TITLE
[#293] SET $ZGBLDIR inside a trigger does not switch global directories in the update process

### DIFF
--- a/sr_port/updproc.c
+++ b/sr_port/updproc.c
@@ -94,6 +94,7 @@
 #include "gvcst_jrt_null.h"	/* for gvcst_jrt_null prototype */
 #include "preemptive_db_clnup.h"
 #include "trap_env_init.h"
+#include "dpgbldir_sysops.h"
 #ifdef DEBUG
 #include "repl_filter.h"	/* needed by an assert in UPD_GV_BIND_NAME_APPROPRIATE macro */
 #endif
@@ -1235,10 +1236,17 @@ void updproc_actions(gld_dbname_list *gld_db_files)
 						}
 					}
 					/* Triggers can change the GLD references. Verify and restore as needed */
-					if (gd_header != starting_gd_header)
+					if ((gd_header != starting_gd_header) || (TREF(gd_targ_addr) != gd_header))
+					{
+						dpzgbini();	/* Equivalent of SET $ZGBLDIR="", needed in case triggers
+								 * did a SET $ZGBLDIR=... that has to be undone once trigger
+								 * returns. Not doing so can cause future SET $ZGBLDIR= to
+								 * incorrectly return prematurely because dollar_zgbldir
+								 * was not maintained in sync with gd_header.
+								 */
 						gd_header = starting_gd_header;
-					if (TREF(gd_targ_addr) != gd_header)
 						TREF(gd_targ_addr) = gd_header;
+					}
 #					endif
 					if ((upd_good_record == bad_trans_type) && !IS_TP(rectype))
 						incr_seqno = TRUE;


### PR DESCRIPTION
SET $ZGBLDIR inside a trigger does the switch the first time. That changes the dollar_zgbldir.str
mstr to point to the new global directory. But once the trigger returns, the update process
switched gd_header back to what it was before the trigger was invoked (done as part of GTM-8789
in GT.M V6.3-003). But this does not switch dollar_zgbldir.str back to point to the original
gbldir. This out-of-sync situation means that future trigger invocations that do the SET $ZGBLDIR
to the same new global directory as before will incorrectly conclude (in op_svput) that
dollar_zgbldir.str already points to the gbldir of interest and so return prematurely. This means
that updates which happen inside the trigger will go to the original gbldir (with which the update
process started) and not the gbldir indicated in the SET $ZGBLDIR.

This is now fixed by doing a dpzgbini() call when gd_header is restored after a trigger returns.
This will result in dollar_zgbldir being in sync with gd_header.