### PR TITLE
[#295] ZSTEP inside trigger should be ignored completely if TRIGGER_MOD restriction is in place

### DIFF
--- a/sr_port/op_zst_break.c
+++ b/sr_port/op_zst_break.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -11,6 +14,7 @@
  ****************************************************************/
 
 #include "mdef.h"
+
 #include <rtnhdr.h>
 #include "stack_frame.h"
 #include "xfer_enum.h"
@@ -21,24 +25,23 @@
 #include "restrict.h"
 
 GBLREF stack_frame	*frame_pointer;
-GBLREF int4		gtm_trigger_depth;
 GBLREF xfer_entry_t	xfer_table[];
 GBLREF mval 		zstep_action;
+#ifdef DEBUG
+GBLREF int4		gtm_trigger_depth;
+#endif
 
 void op_zst_break(void)
 {
-	if ((0 < gtm_trigger_depth) && (RESTRICTED(trigger_mod)))
-		return;
+	assert((0 == gtm_trigger_depth) || !RESTRICTED(trigger_mod));
 	FIX_XFER_ENTRY(xf_linefetch, op_linefetch);
 	FIX_XFER_ENTRY(xf_linestart, op_linestart);
 	FIX_XFER_ENTRY(xf_zbfetch, op_zbfetch);
 	FIX_XFER_ENTRY(xf_zbstart, op_zbstart);
 	FIX_XFER_ENTRY(xf_ret, opp_ret);
 	FIX_XFER_ENTRY(xf_retarg, op_retarg);
-
 	flush_pio();
 	op_commarg(&zstep_action,indir_linetail);
 	zstep_action.mvtype = 0;
 	frame_pointer->type = SFT_ZSTEP_ACT;
 }
-

--- a/sr_port/op_zstep.c
+++ b/sr_port/op_zstep.c
@@ -14,6 +14,7 @@
  ****************************************************************/
 
 #include "mdef.h"
+
 #include "zstep.h"
 #include <rtnhdr.h>
 #include "stack_frame.h"
@@ -21,6 +22,7 @@
 #include "indir_enum.h"
 #include "op.h"
 #include "fix_xfer_entry.h"
+#include "restrict.h"
 
 GBLREF xfer_entry_t     xfer_table[];
 GBLREF stack_frame	*frame_pointer;
@@ -29,7 +31,7 @@ GBLREF mval		zstep_action;
 GBLREF bool		neterr_pending;
 GBLREF int4		outofband;
 GBLREF int		iott_write_error;
-IA64_ONLY(int function_type(char*);)
+GBLREF int4		gtm_trigger_depth;
 
 void op_zstep(uint4 code, mval *action)
 {
@@ -38,6 +40,8 @@ void op_zstep(uint4 code, mval *action)
 	DCL_THREADGBL_ACCESS;
 
 	SETUP_THREADGBL_ACCESS;
+	if ((0 < gtm_trigger_depth) && RESTRICTED(trigger_mod))
+		return;
 	if (!action)
 		zstep_action = TREF(dollar_zstep);
 	else


### PR DESCRIPTION
GTM-8842 fixed this issue in GT.M V6.3-003 but the fix seems incorrect. The change was
done in op_set_zbreak() to return if we are inside a trigger. But by the time op_set_zbreak()
is invoked, the transfer table has already been changed by op_zstep.c in preparation for
the ZSTEP action. This undo happens much later when op_set_zbreak() is called after we
finish executing the trigger at which point, the current $ZSTEP action is executed too.
This is an unintended side effect which is considered incorrect. A ZSTEP action which was
ignored while inside a trigger should continue to be ignored after exiting the trigger too.

The fix is to remove the change done in op_set_zbreak() but move that check to op_zstep.c
so we do not do any transfer table change while inside a trigger and if TRIGGER_MOD restriction
is currently on. This change to op_zstep.c mirrors a change to op_zbreak.c done as part of
GTM-8842.