### PR TITLE
[#297] LOCK commands can spin-loop/hang and incorrectly seize ownership in rare cases

### DIFF
--- a/sr_port/mlk_shrblk_create.c
+++ b/sr_port/mlk_shrblk_create.c
@@ -13,14 +13,22 @@
  *								*
  ****************************************************************/
 
-#include <stddef.h>
 #include "mdef.h"
+
+#include <stddef.h>
 
 #include "gtm_string.h"
 
 #include "mlkdef.h"
 #include "copy.h"
 #include "mlk_shrblk_create.h"
+#include "gdsroot.h"
+#include "gtm_facility.h"
+#include "fileinfo.h"
+#include "gdsbt.h"
+#include "gdsfhead.h"
+#include "filestruct.h"
+#include "gdsbgtr.h"
 
 void mlk_shrhash_add(mlk_pvtblk *p, mlk_shrblk_ptr_t shr, int subnum);
 
@@ -125,7 +133,12 @@ void mlk_shrhash_add(mlk_pvtblk *p, mlk_shrblk_ptr_t shr, int subnum)
 			 * table is in shared memory, it cannot be resized (needs shared memory size change which
 			 * is not easily possible). Degenerate to linear search scheme for just this bucket.
 			 */
+			sgmnt_addrs	*csa;
+
 			bucket_full = TRUE;
+			csa = &FILE_INFO(p->region)->s_addrs;
+			/* Record this rare event in the file header */
+			BG_TRACE_PRO_ANY(csa, lock_hash_bucket_full);
 			break;
 		}
 		/* Move the bucket from the mapped bucket to the free bucket */

--- a/sr_port/mlk_shrblk_delete_if_empty.c
+++ b/sr_port/mlk_shrblk_delete_if_empty.c
@@ -117,6 +117,7 @@ void mlk_shrhash_delete(mlk_ctldata_ptr_t ctl, mlk_shrblk_ptr_t d)
 	}
 	search_bucket->shrblk = 0;
 	search_bucket->hash = 0;
+	SHRHASH_DEBUG_ONLY(mlk_shrhash_validate(ctl));
 	return;
 }
 

--- a/sr_port/mlkdef.h
+++ b/sr_port/mlkdef.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -67,11 +70,14 @@ typedef struct
 					 * shrblk/shrsub chain
 					 */
 	uint4		usedmap;	/* Bitmap representing the bucket neighborhood, with bit N set if (bucket+N) % nbuckets
-					 * is an overflow from this bucket (or the bucket itself, for N=0.)
+					 * is an overflow from this bucket (or the bucket itself, for N=0).
+					 * N == MLK_SHRHASH_HIGHBIT is a special case indicating a bucket full situation was
+					 * encountered and so a linear search has to be used when searching.
 					 */
 } mlk_shrhash;
 
-#define MLK_SHRHASH_NEIGHBORS	(SIZEOF(((mlk_shrhash *)0)->usedmap) * BITS_PER_UCHAR)
+#define MLK_SHRHASH_NEIGHBORS	((SIZEOF(((mlk_shrhash *)0)->usedmap) * BITS_PER_UCHAR) - 1)
+#define	MLK_SHRHASH_HIGHBIT	MLK_SHRHASH_NEIGHBORS
 
 typedef struct				/* the subscript value of a single node in a tree.  Stored separately so that
 					 * the mlk_shrblk's can all have fixed positions, and yet we can

--- a/sr_port/mlkdef.h
+++ b/sr_port/mlkdef.h
@@ -130,6 +130,16 @@ typedef mlk_shrsub	*mlk_shrsub_ptr_t;
 typedef mlk_ctldata	*mlk_ctldata_ptr_t;
 typedef mlk_shrhash	*mlk_shrhash_ptr_t;
 
+/* Uncomment the below line if you want to turn on lock hash debugging.
+ * #define MLK_SHRHASH_DEBUG
+ */
+#ifdef MLK_SHRHASH_DEBUG
+#	define SHRHASH_DEBUG_ONLY(x) x
+	void mlk_shrhash_validate(mlk_ctldata_ptr_t ctl);
+#else
+#	define SHRHASH_DEBUG_ONLY(x)
+#endif
+
 #ifdef DB64
 # ifdef __osf__
 #  pragma pointer_size(restore)

--- a/sr_port/tab_bg_trc_rec.h
+++ b/sr_port/tab_bg_trc_rec.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2005-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -159,3 +162,10 @@ TAB_BG_TRC_REC("  LseekAIORestart EAGAIN", async_restart_eagain)
 TAB_BG_TRC_REC("  JnlBuff Phs2Cmt Full  ", jnlbuff_phs2cmt_array_full)
 TAB_BG_TRC_REC("  JnlPhs2ClnupIfPossible", jnl_phase2_cleanup_if_possible)
 TAB_BG_TRC_REC("  JnlBuff Phs2Cmt PrcAlv", jnlbuff_phs2cmt_isprcalv)
+/* Add next YottaDB specific entry backwards from end of filler section (currently two entries).
+ * This way YottaDB additions won't collide with GT.M additions (if any) as they happen from the beginning
+ * of the filler section.
+ */
+TAB_BG_TRC_REC("                        ", filler1)
+TAB_BG_TRC_REC("                        ", filler2)
+TAB_BG_TRC_REC("  Lock Hash Bucket Full ", lock_hash_bucket_full)


### PR DESCRIPTION
See description at https://github.com/YottaDB/YottaDB/issues/297 for background on issue.

As for a fix, the hopscotch algorithm is modified to use 31 as H (instead of 32). So there will
be 31 neighbor buckets instead of 32 buckets. The highbit (bit 31) is set whenever we end up with
a situation where all neighbor buckets are full when we try to add a key to the mlk_shrhash table.

If we find the highbit set, we do a linear search of the entire hash buckets array instead
of just the 31 neighbor buckets to check if a key exists or not. A similar logic is used for
deletion of an entry from the mlk_shrhash table too.

This modified hopscotch algorithm handles the bucket-full situation (a very rare scenario) with a
slower linear search. It still continues to use the much faster hash algorithm for all hash buckets where
there is less than 31 collisions (the most common case). But this removes the hangs and
lock-ownership-seizes that can happen in rare cases with the previous implementation.