### PR TITLE
[#310] Garbage device name in DEVOPENFAIL message in syslog after an error in OPEN of a PIPE device

### DIFF
--- a/sr_port/get_log_name.c
+++ b/sr_port/get_log_name.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -21,8 +24,6 @@
 GBLREF io_log_name *io_root_log_name;
 
 error_def(ERR_INVSTRLEN);
-
-#define LOGNAME_LEN 255
 
 io_log_name *get_log_name(mstr *v, bool insert)
 {

--- a/sr_port/io.h
+++ b/sr_port/io.h
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2018 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -80,6 +83,8 @@ error_def(ERR_UTF16ENDIAN);
 
 #define BADCHAR_DEVICE_MSG "BADCHAR error raised on input"
 #define UNAVAILABLE_DEVICE_MSG "Resource temporarily unavailable"
+
+#define LOGNAME_LEN 255	/* Maximum possible length of name in "io_log_name.dollar_io[]". Enforced by "get_log_name". */
 
 typedef unsigned char params;
 


### PR DESCRIPTION
In the v62001/gtm8094pipproc subtest, a recent test enhancement to print the complete DEVOPENFAIL
syslog message resulted in an occasional test failure where the device name was printed as garbage.

For example,

Expected message was
%YDB-E-DEVOPENFAIL, Error opening uname,
	%YDB-I-TEXT, PIPE - dup2(pfd_write[0]) failed in child, %SYSTEM-E-UNKNOWN, Unknown system error 0

Actual message was
%YDB-E-DEVOPENFAIL, Error opening .......$...............q5............. .......q......,
	%YDB-I-TEXT, PIPE - dup2(pfd_write[0]) failed in child, %SYSTEM-E-UNKNOWN, Unknown system error 0

This turned out to be a longstanding code issue in iopi_open.c.

In the forked off child process in iopi_open(), there are various places where system calls
could error out. In that case, we issue a DEVOPENFAIL error to syslog using dev_name->dollar_io
as the device name. But because an io_rundown() has already been done in the child, the contents
of dev_name are not reliable anymore.

The fix is to copy dev_name->dollar_io and dev_name->len into a local buffer before the io_rundown() call.
Thankfully this is possible with a stack variable since the name is limited to a max of LOGNAME_LEN
(i.e. 255 bytes) in get_log_name().