### PR TITLE
Make TPNOTACID message more informative in case of /WAIT, /PASS, /ACCEPT or /TLS usages

### DIFF
--- a/sr_port/iosocket_iocontrol.c
+++ b/sr_port/iosocket_iocontrol.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -63,7 +66,6 @@ error_def(ERR_INVCTLMNE);
 #define READ		"READ|"
 #define MAXEVENTLITLEN	(SIZEOF(LISTENING)-1)
 #define MAXZKEYITEMLEN	(MAX_HANDLE_LEN + SA_MAXLITLEN + MAXEVENTLITLEN + 2)	/* 1 pipe and a semicolon */
-#define FORMATTIMESTR "FORMAT"
 
 void	iosocket_iocontrol(mstr *mn, int4 argcnt, va_list args)
 {
@@ -103,7 +105,7 @@ void	iosocket_iocontrol(mstr *mn, int4 argcnt, va_list args)
 	{
 		arg = (0 < argcnt) ? va_arg(args, mval *) : (mval *)&literal_notimeout;
 		if ((NULL != arg) && !M_ARG_SKIPPED(arg) && MV_DEFINED(arg))
-			MV_FORCE_MSTIMEOUT(arg, msec_timeout, FORMATTIMESTR);
+			MV_FORCE_MSTIMEOUT(arg, msec_timeout, "/WAIT");
 		else
 		{
 			rts_error_csa(CSA_ARG(NULL) VARLSTCNT(1) ERR_EXPR);
@@ -131,7 +133,7 @@ void	iosocket_iocontrol(mstr *mn, int4 argcnt, va_list args)
 				arg = (mval *)&literal_notimeout;
 		} else
 			arg = (mval *)&literal_notimeout;
-		MV_FORCE_MSTIMEOUT(arg, msec_timeout, FORMATTIMESTR);
+		MV_FORCE_MSTIMEOUT(arg, msec_timeout, "/PASS");
 		iosocket_pass_local(io_curr_device.out, pid, msec_timeout, n, args);
 	} else if (0 == memcmp(action, "ACCEPT", length))
 	{
@@ -161,7 +163,7 @@ void	iosocket_iocontrol(mstr *mn, int4 argcnt, va_list args)
 				arg = (mval *)&literal_notimeout;
 		} else
 			arg = (mval *)&literal_notimeout;
-		MV_FORCE_MSTIMEOUT(arg, msec_timeout, FORMATTIMESTR);
+		MV_FORCE_MSTIMEOUT(arg, msec_timeout, "/ACCEPT");
 		iosocket_accept_local(io_curr_device.in, handlesvar, pid, msec_timeout, n, args);
 #ifdef	GTM_TLS
 	} else if (0 == memcmp(action, "TLS", length))
@@ -188,7 +190,7 @@ void	iosocket_iocontrol(mstr *mn, int4 argcnt, va_list args)
 				arg = (mval *)&literal_notimeout;
 		} else
 			arg = (mval *)&literal_notimeout;
-		MV_FORCE_MSTIMEOUT(arg, msec_timeout, FORMATTIMESTR);
+		MV_FORCE_MSTIMEOUT(arg, msec_timeout, "/TLS");
 		if (3 <= argcnt)
 		{
 			tlsid = va_arg(args, mval *);


### PR DESCRIPTION
The v63002/gtm8165 subtest created a scenario where TPNOTACID messages were sent to the syslog
for a variety of command usages. For commands like HANG, LOCK or OPEN, it clearly indicated the name
of the command that caused the message. An example message for the OPEN command is the below

%YDB-I-TPNOTACID, OPEN at opentimeout+5^gtm8165 violates ACID properties of a TRANSACTION and could exceed .123 seconds;

But when the command causing the TPNOTACID was a WRITE /WAIT or a WRITE /PASS or WRITE /ACCEPT
or WRITE /TLS, the message read as follows

%YDB-I-TPNOTACID, FORMAT at writeslashpass+14^gtm8165 violates ACID properties of a TRANSACTION and could exceed .123 seconds;

Note the word FORMAT. I guess this is intended to indicate that a command involving a format character
"/" was used. But it is not user-friendly. So this is fixed to indicate exactly which sub-command
was specified. The message after the code fixes reads as follows.

%YDB-I-TPNOTACID, /PASS at writeslashpass+14^gtm8165 violates ACID properties of a TRANSACTION and could exceed .123 seconds;

It would be better if we can indicate WRITE /PASS, the full command, instead of just /PASS. But that
information is lost in compilation so when control comes to iosocket_iocontrol.c, we do not know if
we came there because of a WRITE /PASS or a READ /PASS. Both end up doing the same thing even though
only WRITE /PASS etc. is documented (none of READ /WAIT, READ /PASS, READ /ACCEPT or READ /TLS is documented).