### PR TITLE
[#324] Error inside indirection usage in direct mode using $ETRAP (not $ZTRAP) causes process to incorrectly terminate

### DIFF
--- a/sr_port/trans_code_cleanup.c
+++ b/sr_port/trans_code_cleanup.c
@@ -3,6 +3,9 @@
  * Copyright (c) 2001-2017 Fidelity National Information	*
  * Services, Inc. and/or its subsidiaries. All rights reserved.	*
  *								*
+ * Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	*
+ * All rights reserved.						*
+ *								*
  *	This source code contains the intellectual property	*
  *	of its copyright holder(s), and is made available	*
  *	under a license.  If you do not know the terms of	*
@@ -113,7 +116,7 @@ void trans_code_cleanup(void)
 				 * is not a direct mode frame, we'll assert in debug or break in pro and just continue.
 				 * to direct mode.
 				 */
-				assert(fp->flags && (SFF_INDCE));
+				assert(fp->flags & SFF_INDCE);
 				if (!fp->old_frame_pointer || !(fp->old_frame_pointer->type & SFT_DM))
 				{
 					assert(FALSE);


### PR DESCRIPTION
The way direct mode check was done in mdb_condition_handler() was to check if the frame
immediately previous to the current frame is a direct-mode frame (SFT_DM) or if we are in compile
time and if so check if the current frame is a direct-mode frame. This meant that if an error
occurs inside an indirection usage (which translates to an arbitrary number of uncounted frames
underneath the SFT_DM frame), we would end up treating that error as coming from a non-direct-mode
action which is inconsistent since the same error outside of the indirection will be treated as if
it happened in direct-mode. This inconsistency is fixed by checking all frames back from the current
one until we see either a counted frame or a SFT_DM frame. And using that to decide whether we
are in direct mode or not.

Note that this change does not discard the special handling previously done for TREF(compile_time).
In that case, we start from "frame_pointer" instead of "frame_pointer->old_frame_pointer". I don't see
a reason why that is needed but did not want to change it without reason so letting it stay as is.