### PR TITLE
[#312] Fix assert that is not accurate in one case exposed by r124/ydb312_gtm8182d subtest

### DIFF
--- a/sr_unix/jnlpool_init.c
+++ b/sr_unix/jnlpool_init.c
@@ -624,7 +624,8 @@ void jnlpool_init(jnlpool_user pool_user, boolean_t gtmsource_startup, boolean_t
 			RTS_ERROR_LITERAL("Error with journal pool shmat"), save_errno);
 	}
 	assert(jnlpool == tmp_jnlpool);
-	assert((NULL == gd_ptr) || (NULL == gd_ptr->gd_runtime->jnlpool));
+	assert((NULL == gd_ptr) || (NULL == gd_ptr->gd_runtime->jnlpool)
+		|| (!new_tmp_jnlpool && (tmp_jnlpool == gd_ptr->gd_runtime->jnlpool) && !tmp_jnlpool->pool_init));
 	ADD_TO_JNLPOOL_HEAD_LIST(new_tmp_jnlpool, jnlpool, jnlpool_head, gd_ptr);
 	jnlpool->jnlpool_ctl = tmp_jnlpool_ctl;
 	/* Now that we have attached to the journal pool, fix udi->counter_ftok_incremented back to an accurate value */


### PR DESCRIPTION
In this subtest, we do a jnlpool_init(GTMRELAXED) for a read access because ydb_custom_errors/gtm_custom_errors
env var is set. But the jnlpool is not set up yet. And so the jnlpool_init(GTMRELAXED) call allocates a
"jnlpool" structure but has a "jnlpool_ctl" pointer set to NULL when it returns. Later the test
starts the source server (using a zsystem) and then attempts an update on a database. This does a
jnlpool_init(GTMPROC) call which finds the previously allocated "jnlpool" structure and reuses it correctly
but has an assert that the jnlpool pointer from the gld should be NULL. It is not NULL due to the prior
jnlpool_init(GTMRELAXED) call. The fix is to add an || condition which verifies this particular scenario.