### PR TITLE
[GTM-5059] Fix code to match V6.3-005 release note when gtm_mstack_crit_threshold env var is set to 0

### DIFF
--- a/sr_port/mstack_size_init.c
+++ b/sr_port/mstack_size_init.c
@@ -61,7 +61,7 @@ void mstack_size_init(struct startup_vector *svec)
 							MSTACK_MIN_SIZE, MSTACK_MAX_SIZE, ydb_mstack_size);
 	ydb_mstack_crit_threshold = ydb_trans_numeric(YDBENVINDX_MSTACK_CRIT_THRESHOLD, &is_defined, IGNORE_ERRORS_TRUE, NULL);
 	invalid_value = 0;
-	if (0 == ydb_mstack_crit_threshold)
+	if (!is_defined)
 		ydb_mstack_crit_threshold = MSTACK_CRIT_DEF_THRESHOLD;
 	else if (MSTACK_CRIT_MIN_THRESHOLD > ydb_mstack_crit_threshold)
 	{


### PR DESCRIPTION
The V6.3-005 release notes had the following mention about GTM-5059.
```
GT.M recognizes setting the environment variable gtm_mstack_crit_threshold to specify an integer
between 15 and 95 defining the percentage of the stack which should be used before GT.M emits a
STACKCRIT warning. If the value is below the minimum or above the maximum GT.M uses the minimum or
maximum respectively. The default is 90.
```
But in testing, we found that when gtm_mstack_crit_threshold env var is set to 0, the default is
assumed whereas the release note indicates the minimum will be assumed (because 0 is less than the
minimum of 15). The code is now fixed to match the release note so if the env var is set to 0,
the minimum of 15 is assumed.