### PR TITLE
[GTM-5574] Fix %OD and %OH to not issue incorrect NUMOFLOW error in case a huge octal number (>= 10**47) is specified

### DIFF
--- a/sr_port/od.mpt
+++ b/sr_port/od.mpt
@@ -3,6 +3,9 @@
 ; Copyright (c) 1987-2018 Fidelity National Information		;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -19,5 +22,5 @@
 INT	r !,"Octal: ",%OD s %OD=$$FUNC(%OD)
 	q
 FUNC(o)
-	q:o<0 ""
+	q:"-"=$ze(o,1) ""
 	q $$CONVERTBASE^%CONVBASEUTIL(o,8,10)

--- a/sr_port/oh.mpt
+++ b/sr_port/oh.mpt
@@ -3,6 +3,9 @@
 ; Copyright (c) 1987-2018 Fidelity National Information		;
 ; Services, Inc. and/or its subsidiaries. All rights reserved.	;
 ;								;
+; Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	;
+; All rights reserved.						;
+;								;
 ;	This source code contains the intellectual property	;
 ;	of its copyright holder(s), and is made available	;
 ;	under a license.  If you do not know the terms of	;
@@ -21,7 +24,7 @@ INT	r !,"Octal: ",%OH s %OH=$$FUNC(%OH)
 	q
 FUNC(o)
 	q:o=0 0
-	q:o<0 ""
+	q:"-"=$ze(o,1) ""
 	q:o'?1.N ""
 	q:o[8!(o[9) ""
 	q $$CONVERTBASE^%CONVBASEUTIL(o,8,16)


### PR DESCRIPTION
This was mentioned as having been fixed in GTM-5574 in GT.M V6.3-005 but we noticed during testing
that it was not. Only %OD and %OH seemed to have the NUMOFLOW issue. The others (e.g. %HO, %HD etc.)
worked fine.