### PR TITLE
[#343] Ensure Ctrl-C on a long-running ZWRITE clears the internal zwrite-is-active flag or else debug-only assert failures can occur

### DIFF
--- a/sr_port/mdb_condition_handler.c
+++ b/sr_port/mdb_condition_handler.c
@@ -293,15 +293,12 @@ CONDITION_HANDLER(mdb_condition_handler)
 	MDB_START;
 	assert(FALSE == in_gvcst_incr);	/* currently there is no known case where this can be TRUE at this point */
 	in_gvcst_incr = FALSE;	/* reset this just in case gvcst_incr/gvcst_put failed to do a good job of resetting */
-	if ((SUCCESS != SEVERITY) && (INFO != SEVERITY))
-	{
-		inctn_opcode = inctn_invalid_op;
-		/* Ideally merge should have a condition handler to reset followings, but generated code can call other routines
-		 * during MERGE command (MERGE command invokes multiple op-codes depending on source vs target). So it is not
-		 * easy to establish a condition handler there. Easy solution is following one line code.
-		 */
-		NULLIFY_MERGE_ZWRITE_CONTEXT;
-	}
+	inctn_opcode = inctn_invalid_op;
+	/* Ideally merge should have a condition handler to reset followings, but generated code can call other routines
+	 * during MERGE command (MERGE command invokes multiple op-codes depending on source vs target). So it is not
+	 * easy to establish a condition handler there. Easy solution is following one line code.
+	 */
+	NULLIFY_MERGE_ZWRITE_CONTEXT;
 	if ((int)ERR_TPRETRY == SIGNAL)
 	{
 		lcl_error_frame = error_frame;

--- a/sr_port/unw_mv_ent.c
+++ b/sr_port/unw_mv_ent.c
@@ -499,6 +499,9 @@ void unw_mv_ent(mv_stent *mv_st_ent)
 			restart_ctxt = mv_st_ent->mv_st_cont.mvs_rstrtpc.restart_ctxt_save;
 			return;
 		case MVST_MRGZWRSV:
+			/* Note: The below code restores what was saved in PUSH_MVST_MRGZWRSV_IF_NEEDED.
+			 *       Ensure the two are kept in sync.
+			 */
 			merge_args = mv_st_ent->mv_st_cont.mvs_mrgzwrsv.save_merge_args;
 			zwrtacindx = mv_st_ent->mv_st_cont.mvs_mrgzwrsv.save_zwrtacindx;
 			if (NULL != mglvnp)
@@ -507,6 +510,7 @@ void unw_mv_ent(mv_stent *mv_st_ent)
 				FREEIFALLOC(mglvnp->gblp[1]);
 				free(mglvnp);
 			}
+			TREF(in_zwrite) = mv_st_ent->mv_st_cont.mvs_mrgzwrsv.save_in_zwrite;
 			mglvnp = mv_st_ent->mv_st_cont.mvs_mrgzwrsv.save_mglvnp;
 			if (NULL != lvzwrite_block)
 			{


### PR DESCRIPTION
TREF(in_zwrite) is set to TRUE at the start of a ZWRITE. If the ZWRITE is run in direct mode (i.e. the
YDB> prompt) and runs for a long time so the user interrupts it with a Ctrl-C, a YDB-I-CTLRC error is
issued and control returns to the YDB> prompt. After that if the user runs an M command that contains
an lvn, one gets an assert failure while running a debug build of YottaDB.

%YDB-F-ASSERT, Assert failed in sr_port/gtm_fetch.c line 73 for expression (!TREF(in_zwrite))

This is because TREF(in_zwrite) was not set to FALSE when the Ctrl-C happened. It should have been reset
in mdb_condition_handler() but that had code to invoke NULLIFY_MERGE_ZWRITE_CONTEXT (the macro which
resets TREF(in_zwrite) among other things) only if the error severity is ERROR or FATAL. But the CTRLC
error severity is INFO and so it did not clear TREF(in_zwrite).

In V6.2-001, mdb_condition_handler() did the clear of TREF(in_zwrite) unconditionally but in V6.2-002,
this was moved into a pre-existing if block (that checked whether severity is ERROR or FATAL) and folded
into a new macro NULLIFY_MERGE_ZWRITE_CONTEXT. It is not clear why this change was necessary. Clearing
the interrupted zwrite and/or merge context seems safe to do on any error even if it is a SUCCESS or
INFO type. So have moved the NULLIFY_MERGE_ZWRITE_CONTEXT macro outside the "if" block. This way all
zwrite-related context (including lvzwrite_block which is local-variable related context of ZWRITE) is
now reset on a CTRLC error. Seems the right thing to do.